### PR TITLE
Enable root SSH access on Proxmox host

### DIFF
--- a/hosts/proxmox/configuration.nix
+++ b/hosts/proxmox/configuration.nix
@@ -65,8 +65,9 @@
   # Root sans mot de passe (SSH root déjà interdit)
   users.users.root.password = null;
 
-  # Sudo
+  # Sudo - Permet au groupe wheel d'exécuter toutes les commandes sans mot de passe
   security.sudo.enable = true;
+  security.sudo.wheelNeedsPassword = false;
 
   # QEMU Guest Agent
   services.qemuGuest.enable = true;


### PR DESCRIPTION
- Active wheelNeedsPassword = false pour le groupe wheel
- Permet à jeremie d'utiliser sudo sans mot de passe
- Maintient la sécurité en gardant PermitRootLogin = "no"
- Permet l'accès root via `sudo -i` ou `sudo su`