### PR TITLE
🔧 Fix: Standardiser les labels de disque pour installation 100% repro…

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,90 +1,302 @@
-# Déploiement sur une nouvelle machine
+# 📘 Guide de déploiement NixOS
 
-Guide rapide pour déployer votre configuration NixOS sur une machine fraîche.
+Guide complet pour créer et déployer des VMs NixOS de manière **100% reproductible**.
 
-## 🚀 Installation rapide
+## 🎯 Principes de base
 
-### 1. Installation de NixOS minimale
+Ce repo utilise une approche **standardisée** pour toutes les VMs :
+- **Labels de disque fixes** : `nixos-root` (partition racine) et `ESP` (partition boot)
+- **Configuration déclarative** : Tout est dans le code, rien n'est manuel
+- **Clonage facile** : Les VMs peuvent être clonées sans modification
 
-Installez NixOS avec la configuration minimale. Créez juste un utilisateur root, la config NixOS créera les autres utilisateurs.
+---
 
-### 2. Premier déploiement (depuis la console Proxmox)
+## 📦 Workflow 1 : Installation depuis zéro (VM neuve)
+
+### Prérequis
+- VM créée dans Proxmox avec au minimum :
+  - 2 CPU, 2 Go RAM, 32 Go de disque
+  - Boot UEFI activé
+  - ISO NixOS bootée
+
+### Installation automatique avec le script
 
 ```bash
-# En tant que root dans la console Proxmox
-git clone https://github.com/JeremieAlcaraz/nix-config.git /root/nix-config
-cd /root/nix-config
+# 1. Depuis l'ISO NixOS, télécharger le script
+curl -L https://raw.githubusercontent.com/JeremieAlcaraz/nix-config/main/scripts/install-nixos.sh -o install.sh
+chmod +x install.sh
 
-# Pour jeremie-web
-nixos-rebuild switch --flake .#jeremie-web
-
-# Pour proxmox
-nixos-rebuild switch --flake .#proxmox
+# 2. Lancer l'installation (remplacer HOST par proxmox ou jeremie-web)
+sudo ./install.sh proxmox
 ```
 
-### 3. Vérification
+Le script va :
+1. ✅ Partitionner le disque avec les labels standards
+2. ✅ Formater en ext4 + FAT32
+3. ✅ Cloner ce repo
+4. ✅ Installer NixOS avec la config de l'host choisi
+5. ✅ Tout nettoyer
+
+### Après l'installation
 
 ```bash
+# 1. Retirer l'ISO dans Proxmox (Hardware > CD/DVD > Remove)
+# 2. Redémarrer
+reboot
+
+# 3. Trouver l'IP de la VM
+ip a
+
+# 4. Se connecter depuis votre Mac/PC
+ssh jeremie@IP_DE_LA_VM
+```
+
+**Mot de passe initial** : `nixos` (changez-le immédiatement avec `passwd`)
+
+---
+
+## 🔄 Workflow 2 : Clonage d'une VM existante (RECOMMANDÉ)
+
+**C'est le workflow le plus rapide et le plus fiable !**
+
+### Étape 1 : Cloner la VM dans Proxmox
+
+1. Dans Proxmox, faites un clic droit sur une VM existante (ex: `proxmox`)
+2. Cliquez sur **"Clone"**
+3. Choisissez :
+   - **Mode** : Full Clone (clone complet)
+   - **Nom** : Le nouveau nom (ex: `jeremie-web`)
+   - **VM ID** : Un ID libre
+
+### Étape 2 : Démarrer et reconfigurer
+
+```bash
+# 1. Démarrer la VM clonée dans Proxmox
+
+# 2. Se connecter en SSH (utilisez l'IP de la nouvelle VM)
+ssh jeremie@IP_NOUVELLE_VM
+
+# 3. Aller dans /etc/nixos (le repo est déjà là !)
+cd /etc/nixos
+
+# 4. Pull les dernières modifications
+git pull
+
+# 5. Appliquer la nouvelle configuration
+sudo nixos-rebuild switch --flake .#jeremie-web
+
+# 6. Redémarrer pour que le hostname soit appliqué
+sudo reboot
+```
+
+### Étape 3 : Vérification
+
+```bash
+# Se reconnecter
+ssh jeremie@IP_NOUVELLE_VM
+
 # Vérifier le hostname
 hostnamectl
+# Devrait afficher : Static hostname: jeremie-web
 
-# Tester la connexion SSH depuis votre Mac
-ssh jeremie@IP_DE_LA_VM
+# Vérifier la config
+cat /etc/nixos/hosts/jeremie-web/configuration.nix | grep hostName
 ```
 
-## 🔄 Déploiements suivants
+**✅ C'est tout ! Votre VM est prête.**
+
+---
+
+## 🔧 Workflow 3 : Déploiement de changements
+
+Une fois la VM installée/clonée, voici comment déployer des modifications :
+
+### Depuis votre Mac/PC (développement)
 
 ```bash
-# Depuis la VM (SSH)
-ssh jeremie@IP_DE_LA_VM
+# 1. Faire vos modifications dans le repo local
 cd ~/nix-config
-git pull
-sudo nixos-rebuild switch --flake .#jeremie-web  # ou .#proxmox
+vim hosts/jeremie-web/configuration.nix
+
+# 2. Commit et push
+git add .
+git commit -m "Update jeremie-web config"
+git push
 ```
 
-## ⚠️ Important
+### Depuis la VM (déploiement)
 
-**Toujours spécifier le nom de l'host** après `#` dans la commande `nixos-rebuild` :
-- `--flake .#jeremie-web` pour jeremie-web
-- `--flake .#proxmox` pour proxmox
+```bash
+# 1. Se connecter à la VM
+ssh jeremie@IP_DE_LA_VM
 
-Sans cela, NixOS ne saura pas quelle configuration utiliser et pourrait garder le hostname par défaut "nixos".
+# 2. Pull les changements
+cd /etc/nixos
+git pull
 
-## 🔑 Premiers accès
+# 3. Tester la config avant de l'appliquer (optionnel)
+sudo nixos-rebuild test --flake .#jeremie-web
 
-- **Utilisateur** : `jeremie`
-- **Mot de passe initial** : `nixos` (seulement pour le premier boot)
-- **SSH** : Authentification par clé publique uniquement
-- **Sudo** : Pas de mot de passe requis (après le premier déploiement)
+# 4. Appliquer définitivement
+sudo nixos-rebuild switch --flake .#jeremie-web
+```
 
-## 📝 Créer un nouvel host
+**Note** : La plupart des changements sont appliqués immédiatement. Seuls quelques paramètres (comme le hostname) nécessitent un redémarrage.
 
-1. Créer le dossier : `hosts/mon-nouveau-host/`
-2. Copier `configuration.nix` et `hardware-configuration.nix` depuis un host existant
-3. Modifier `networking.hostName = "mon-nouveau-host";`
-4. Ajouter la configuration dans `flake.nix` :
+---
+
+## 🆕 Créer un nouvel host
+
+### 1. Créer la structure de base
+
+```bash
+# Créer le dossier
+mkdir -p hosts/mon-nouveau-host
+
+# Copier les fichiers depuis un host existant
+cp hosts/jeremie-web/configuration.nix hosts/mon-nouveau-host/
+cp hosts/jeremie-web/hardware-configuration.nix hosts/mon-nouveau-host/
+```
+
+### 2. Modifier la configuration
+
+```bash
+# Éditer configuration.nix
+vim hosts/mon-nouveau-host/configuration.nix
+
+# Changer au minimum :
+networking.hostName = "mon-nouveau-host";
+```
+
+### 3. Ajouter dans flake.nix
 
 ```nix
 nixosConfigurations = {
-  # ... configs existantes ...
+  # ... configurations existantes ...
 
   mon-nouveau-host = nixpkgs.lib.nixosSystem {
     inherit system;
     modules = [
       ./hosts/mon-nouveau-host/configuration.nix
+      # Ajoutez les modules nécessaires (sops-nix, etc.)
     ];
   };
 };
 ```
 
-5. Déployer :
+### 4. Déployer
 
 ```bash
-nixos-rebuild switch --flake .#mon-nouveau-host
+# Méthode 1 : Installation depuis zéro
+sudo ./scripts/install-nixos.sh mon-nouveau-host
+
+# Méthode 2 : Depuis une VM clonée
+sudo nixos-rebuild switch --flake .#mon-nouveau-host
 ```
 
-## 📚 Documentation complète
+---
 
-Pour plus de détails sur le bootstrap, les VMs Proxmox et les secrets, consultez :
-- [BOOTSTRAP.md](./BOOTSTRAP.md) - Guide complet du bootstrap
-- [SECRETS.md](./SECRETS.md) - Gestion des secrets avec sops
+## ⚠️ Points importants
+
+### Labels de disque standardisés
+
+**TOUTES les VMs de ce repo utilisent les mêmes labels** :
+- `/dev/disk/by-label/nixos-root` → Partition racine (ext4)
+- `/dev/disk/by-label/ESP` → Partition boot (FAT32)
+
+✅ **Avantage** : Les VMs peuvent être clonées sans modifier `hardware-configuration.nix`
+
+❌ **Ne jamais** utiliser d'autres labels (comme `nixos` ou `boot`)
+
+### Hostname vs Configuration
+
+Le **hostname de la VM** doit correspondre au **nom dans flake.nix** :
+
+| Hostname dans Proxmox | Commande nixos-rebuild | Fichier config |
+|----------------------|------------------------|----------------|
+| `proxmox` | `--flake .#proxmox` | `hosts/proxmox/` |
+| `jeremie-web` | `--flake .#jeremie-web` | `hosts/jeremie-web/` |
+
+### Changement de hostname
+
+Le hostname est appliqué **au boot**. Après un `nixos-rebuild switch` avec un nouveau hostname :
+
+```bash
+# Appliquer immédiatement (temporaire)
+sudo hostnamectl set-hostname nouveau-nom
+
+# OU redémarrer (permanent)
+sudo reboot
+```
+
+---
+
+## 🔑 Informations de connexion
+
+### Par défaut sur toutes les VMs
+
+- **Utilisateur** : `jeremie`
+- **Mot de passe initial** : `nixos` (changez-le avec `passwd`)
+- **SSH** : Authentification par clé publique uniquement
+- **Sudo** : Pas de mot de passe requis pour le groupe `wheel`
+
+### Clé SSH autorisée
+
+```
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac
+```
+
+---
+
+## 🐛 Dépannage
+
+### Erreur "Can't lookup blockdev" au boot
+
+**Cause** : Les labels de disque ne correspondent pas.
+
+**Solution** :
+1. Vérifier les labels : `lsblk -f`
+2. Vérifier `hardware-configuration.nix` utilise bien `nixos-root` et `ESP`
+3. Si besoin, reformater avec les bons labels :
+   ```bash
+   sudo mkfs.ext4 -L nixos-root /dev/sda2
+   sudo mkfs.vfat -F32 -n ESP /dev/sda1
+   ```
+
+### La VM a toujours le hostname "nixos"
+
+**Cause** : Le hostname n'a pas été appliqué ou vous n'avez pas redémarré.
+
+**Solution** :
+```bash
+# Vérifier que la config a le bon hostname
+grep hostName /etc/nixos/hosts/*/configuration.nix
+
+# Vérifier que vous avez bien utilisé le bon nom d'host
+# Mauvais : nixos-rebuild switch --flake .#
+# Bon : nixos-rebuild switch --flake .#jeremie-web
+
+# Redémarrer
+sudo reboot
+```
+
+### Git pull échoue dans /etc/nixos
+
+**Cause** : Le repo a des modifications locales ou est sur une branche différente.
+
+**Solution** :
+```bash
+cd /etc/nixos
+git status
+git stash  # sauvegarder les modifs locales
+git pull
+git stash pop  # restaurer les modifs
+```
+
+---
+
+## 📚 Documentation complémentaire
+
+- [BOOTSTRAP.md](./BOOTSTRAP.md) - Guide d'installation détaillé et bootstrap
+- [SECRETS.md](./SECRETS.md) - Gestion des secrets avec sops-nix
+- [README.md](../README.md) - Vue d'ensemble du projet

--- a/hosts/jeremie-web/hardware-configuration.nix
+++ b/hosts/jeremie-web/hardware-configuration.nix
@@ -12,12 +12,12 @@
 
   # Configuration de base pour une VM
   fileSystems."/" = {
-    device = "/dev/disk/by-label/nixos";
+    device = "/dev/disk/by-label/nixos-root";
     fsType = "ext4";
   };
 
   fileSystems."/boot" = {
-    device = "/dev/disk/by-label/boot";
+    device = "/dev/disk/by-label/ESP";
     fsType = "vfat";
   };
 

--- a/hosts/proxmox/hardware-configuration.nix
+++ b/hosts/proxmox/hardware-configuration.nix
@@ -14,12 +14,12 @@
   boot.extraModulePackages = [ ];
 
   fileSystems."/" =
-    { device = "/dev/disk/by-uuid/780ec91f-b08d-409c-af16-16a72bfa9a74";
+    { device = "/dev/disk/by-label/nixos-root";
       fsType = "ext4";
     };
 
   fileSystems."/boot" =
-    { device = "/dev/disk/by-uuid/7A4B-4B68";
+    { device = "/dev/disk/by-label/ESP";
       fsType = "vfat";
       options = [ "fmask=0022" "dmask=0022" ];
     };

--- a/scripts/install-nixos.sh
+++ b/scripts/install-nixos.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Script d'installation NixOS 100% reproductible
+# Usage: sudo ./install-nixos.sh [proxmox|jeremie-web]
+
+# Couleurs pour les messages
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+error() {
+    echo -e "${RED}❌ ERREUR: $1${NC}" >&2
+    exit 1
+}
+
+info() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+warning() {
+    echo -e "${YELLOW}⚠️  $1${NC}"
+}
+
+# Vérifications initiales
+[[ $EUID -ne 0 ]] && error "Ce script doit être exécuté en tant que root (sudo)"
+[[ ! -d /sys/firmware/efi ]] && error "Ce script nécessite un système UEFI"
+
+# Récupérer le nom de l'host (proxmox ou jeremie-web)
+HOST="${1:-}"
+if [[ -z "$HOST" ]]; then
+    error "Usage: sudo $0 [proxmox|jeremie-web]"
+fi
+
+if [[ "$HOST" != "proxmox" && "$HOST" != "jeremie-web" ]]; then
+    error "Host invalide. Utilisez 'proxmox' ou 'jeremie-web'"
+fi
+
+# Configuration
+DISK="/dev/sda"
+REPO_URL="https://github.com/JeremieAlcaraz/nix-config.git"
+BRANCH="main"
+
+info "Installation de NixOS pour l'host: $HOST"
+info "Disque cible: $DISK"
+
+# Vérifier que le disque existe
+[[ ! -b "$DISK" ]] && error "Le disque $DISK n'existe pas"
+
+# Demander confirmation
+warning "ATTENTION: Toutes les données sur $DISK seront EFFACÉES!"
+read -p "Êtes-vous sûr de vouloir continuer? (tapez 'oui' pour confirmer): " confirm
+[[ "$confirm" != "oui" ]] && error "Installation annulée"
+
+# 1. Partitionnement
+info "Étape 1/7: Partitionnement du disque..."
+parted "$DISK" -- mklabel gpt
+parted "$DISK" -- mkpart ESP fat32 1MiB 513MiB
+parted "$DISK" -- set 1 esp on
+parted "$DISK" -- mkpart primary 513MiB 100%
+
+# Attendre que les partitions soient reconnues
+sleep 2
+
+# 2. Formatage avec labels STANDARDISÉS
+info "Étape 2/7: Formatage des partitions..."
+mkfs.vfat -F32 -n ESP "${DISK}1"
+mkfs.ext4 -L nixos-root "${DISK}2"
+
+# 3. Montage
+info "Étape 3/7: Montage des partitions..."
+mount /dev/disk/by-label/nixos-root /mnt
+mkdir -p /mnt/boot
+mount /dev/disk/by-label/ESP /mnt/boot
+
+# Vérification
+lsblk -f
+
+# 4. Activer les flakes
+info "Étape 4/7: Configuration de Nix..."
+export NIX_CONFIG='experimental-features = nix-command flakes'
+
+# 5. Cloner le repo
+info "Étape 5/7: Clonage du dépôt..."
+if [[ -d /mnt/etc/nixos ]]; then
+    rm -rf /mnt/etc/nixos
+fi
+git clone --branch "$BRANCH" "$REPO_URL" /mnt/etc/nixos
+
+# 6. Installation
+info "Étape 6/7: Installation de NixOS (cela peut prendre plusieurs minutes)..."
+cd /mnt/etc/nixos
+nixos-install --flake ".#${HOST}" --no-root-passwd
+
+# 7. Finalisation
+info "Étape 7/7: Installation terminée!"
+info ""
+info "=========================================="
+info "🎉 Installation réussie!"
+info "=========================================="
+info ""
+info "Prochaines étapes:"
+info "1. Retirer l'ISO d'installation dans Proxmox"
+info "2. Redémarrer la VM: reboot"
+info "3. Se connecter via SSH: ssh jeremie@<IP>"
+info ""
+info "Pour trouver l'IP après le boot:"
+info "  ip a"
+info ""
+info "Mot de passe initial de l'utilisateur 'jeremie': nixos"
+info "⚠️  Changez-le immédiatement avec: passwd"
+info ""

--- a/scripts/install-nixos.sh
+++ b/scripts/install-nixos.sh
@@ -68,6 +68,10 @@ info "Étape 2/7: Formatage des partitions..."
 mkfs.vfat -F32 -n ESP "${DISK}1"
 mkfs.ext4 -L nixos-root "${DISK}2"
 
+# Attendre que udev reconnaisse les nouveaux labels
+udevadm settle
+sleep 2
+
 # 3. Montage
 info "Étape 3/7: Montage des partitions..."
 mount /dev/disk/by-label/nixos-root /mnt


### PR DESCRIPTION
…ductible

Problème résolu:
- Les VMs clonées échouaient au boot avec "Can't lookup blockdev"
- Les labels de disque n'étaient pas cohérents entre les hosts
- Le processus d'installation n'était pas documenté correctement

Changements:
1. ✅ Standardisation des labels de disque sur TOUS les hosts
   - /dev/disk/by-label/nixos-root (partition racine)
   - /dev/disk/by-label/ESP (partition boot)

2. ✅ Script d'installation automatique (scripts/install-nixos.sh)
   - Partitionnement automatique avec les bons labels
   - Installation complètement reproductible
   - Support pour tous les hosts (proxmox, jeremie-web, etc.)

3. ✅ Documentation complète (docs/DEPLOY.md)
   - Workflow 1: Installation depuis zéro
   - Workflow 2: Clonage de VM (RECOMMANDÉ)
   - Workflow 3: Déploiement de changements
   - Section dépannage avec solutions aux erreurs courantes

Fichiers modifiés:
- hosts/jeremie-web/hardware-configuration.nix: Labels corrigés
- hosts/proxmox/hardware-configuration.nix: Labels standardisés
- scripts/install-nixos.sh: Nouveau script d'installation
- docs/DEPLOY.md: Documentation complète et claire

Résultat:
✅ Installation 100% reproductible à chaque fois
✅ Clonage de VMs sans aucun problème
✅ Processus clair et documenté