### PR TITLE
Secure password storage with hashing and sops

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,5 +1,8 @@
 # Configuration sops pour learnix
 # Documentation: https://github.com/Mic92/sops-nix
+#
+# Configuration avec CLÉ PARTAGÉE (plus simple pour un homelab)
+# La même clé est utilisée pour tous les hosts
 
 # Règles de création pour chaque fichier de secrets
 creation_rules:
@@ -7,20 +10,14 @@ creation_rules:
   - path_regex: secrets/jeremie-web\.yaml$
     key_groups:
       - age:
-          # Clé age de l'hôte jeremie-web
-          # À remplacer par la vraie clé publique après le premier boot
-          # Obtenir la clé: ssh root@jeremie-web "cat /var/lib/sops-nix/key.pub"
-          # OU via ssh-to-age: ssh-to-age < /etc/ssh/ssh_host_ed25519_key.pub
-          - &jeremie-web age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        # Ajoutez ici votre clé age personnelle pour pouvoir éditer les secrets
-        # Générer une clé: nix-shell -p age --run "age-keygen"
-        # - &admin age1yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+          # Clé age partagée (générée sur le Mac, copiée sur les VMs)
+          # Localisation : ~/.config/sops/age/nixos-shared-key.txt (Mac)
+          #                /var/lib/sops-nix/key.txt (VMs)
+          - &shared age1nt3ly627s6eqcv97zyw3n489gh7nt2jlrq6mfhucct8wq4lgku6saynhhw
 
   # Secrets pour l'hôte proxmox
   - path_regex: secrets/proxmox\.yaml$
     key_groups:
       - age:
-          # Clé age de l'hôte proxmox
-          # À remplacer par la vraie clé publique après le premier boot
-          # Obtenir la clé: ssh root@proxmox "cat /var/lib/sops-nix/key.pub"
-          - &proxmox age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+          # Même clé partagée que jeremie-web
+          - *shared

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -16,8 +16,11 @@ creation_rules:
         # Générer une clé: nix-shell -p age --run "age-keygen"
         # - &admin age1yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
 
-  # Secrets pour d'autres hôtes (exemple)
-  # - path_regex: secrets/proxmox\.yaml$
-  #   key_groups:
-  #     - age:
-  #         - &proxmox age1zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+  # Secrets pour l'hôte proxmox
+  - path_regex: secrets/proxmox\.yaml$
+    key_groups:
+      - age:
+          # Clé age de l'hôte proxmox
+          # À remplacer par la vraie clé publique après le premier boot
+          # Obtenir la clé: ssh root@proxmox "cat /var/lib/sops-nix/key.pub"
+          - &proxmox age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/docs/SECURE-PASSWORDS.md
+++ b/docs/SECURE-PASSWORDS.md
@@ -1,0 +1,377 @@
+# 🔐 Gestion Sécurisée des Mots de Passe avec sops-nix
+
+Ce guide explique comment gérer de manière sécurisée les mots de passe des utilisateurs avec **sops-nix**.
+
+## 🎯 Pourquoi cette approche ?
+
+### ❌ Problème avec `initialPassword` ou `password`
+```nix
+users.users.jeremie = {
+  initialPassword = "nixos";  # ❌ Mot de passe EN CLAIR dans le repo public !
+};
+```
+
+**Problèmes** :
+- Mot de passe visible par tout le monde sur GitHub
+- Risque de sécurité majeur si oublié de le changer
+- Pas professionnel pour un environnement de production
+
+### ⚠️ Amélioration avec `hashedPassword`
+```nix
+users.users.jeremie = {
+  hashedPassword = "$6$vwZmaAkvi9Sjgv60$...";  # ⚠️ Hash visible dans le repo
+};
+```
+
+**Avantages** :
+- Impossible de retrouver le mot de passe depuis le hash
+- Acceptable pour du développement/test
+
+**Inconvénient** :
+- Le hash est quand même visible dans le repo public
+- Si quelqu'un a accès au hash ET à la VM, il peut tenter du brute-force
+
+### ✅ Solution ULTIME : `hashedPasswordFile` + sops-nix
+```nix
+sops.secrets.jeremie-password-hash = {
+  neededForUsers = true;
+};
+
+users.users.jeremie = {
+  hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
+};
+```
+
+**Avantages** :
+- ✅ Hash chiffré dans le repo (personne ne peut le voir)
+- ✅ Seul l'hôte peut déchiffrer le secret
+- ✅ Sécurité maximale pour la production
+- ✅ Vous avez déjà sops-nix configuré !
+
+## 📋 État Actuel
+
+✅ **Configuration mise en place** :
+- sops-nix activé pour `proxmox` ET `jeremie-web`
+- Fichiers de secrets example créés (`secrets/proxmox.yaml.example`, `secrets/jeremie-web.yaml.example`)
+- `.sops.yaml` configuré pour les deux hosts
+- Les hosts utilisent maintenant `hashedPasswordFile` au lieu de `initialPassword` ou `hashedPassword`
+
+⚠️ **À faire APRÈS le premier boot** :
+1. Récupérer les clés publiques des hosts
+2. Créer et chiffrer les fichiers de secrets
+3. Redéployer avec les secrets chiffrés
+
+## 🚀 Guide d'Utilisation
+
+### Étape 1 : Premier Déploiement (Bootstrap)
+
+Pour le **premier déploiement**, les secrets ne sont pas encore disponibles. Vous avez deux options :
+
+#### Option A : Déployer avec initialPassword temporaire (simple)
+
+Modifier temporairement les fichiers de configuration pour utiliser `initialPassword` :
+
+```nix
+# Dans hosts/jeremie-web/configuration.nix ou hosts/proxmox/configuration.nix
+users.users.jeremie = {
+  isNormalUser = true;
+  createHome = true;
+  home = "/home/jeremie";
+  extraGroups = [ "wheel" ];
+  # Temporaire pour le premier boot
+  initialPassword = "nixos";
+  # Commentez temporairement :
+  # hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
+};
+
+# Commentez aussi temporairement la section sops
+# sops = { ... };
+```
+
+Après le premier boot, vous pourrez suivre les étapes 2-5 pour activer sops.
+
+#### Option B : Utiliser hashedPassword sans sops (plus rapide)
+
+Modifier temporairement pour utiliser directement un hash :
+
+```bash
+# Générer un hash sur votre machine locale
+python3 -c "import crypt; print(crypt.crypt('votre-mot-de-passe', crypt.mksalt(crypt.METHOD_SHA512)))"
+```
+
+Puis dans la configuration :
+```nix
+users.users.jeremie = {
+  isNormalUser = true;
+  createHome = true;
+  home = "/home/jeremie";
+  extraGroups = [ "wheel" ];
+  hashedPassword = "$6$...";  # Votre hash ici
+  # Commentez temporairement :
+  # hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
+};
+
+# Commentez aussi temporairement la section sops
+# sops = { ... };
+```
+
+### Étape 2 : Récupérer les Clés Publiques des Hosts
+
+Une fois les VMs déployées et démarrées, récupérez leurs clés publiques :
+
+```bash
+# Pour jeremie-web
+ssh root@jeremie-web "cat /var/lib/sops-nix/key.pub"
+# Exemple de sortie: age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Pour proxmox
+ssh root@proxmox "cat /var/lib/sops-nix/key.pub"
+# Exemple de sortie: age1yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+```
+
+**Note** : Si `/var/lib/sops-nix/key.pub` n'existe pas, c'est que sops-nix n'a pas encore généré la clé.
+Cela se produit au premier boot avec la configuration sops activée. Si vous avez déployé avec l'Option A ou B,
+vous devrez d'abord activer la configuration sops (étape 5) et redéployer.
+
+### Étape 3 : Mettre à Jour `.sops.yaml`
+
+Remplacez les clés placeholder par les vraies clés :
+
+```yaml
+# .sops.yaml
+creation_rules:
+  - path_regex: secrets/jeremie-web\.yaml$
+    key_groups:
+      - age:
+          - &jeremie-web age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  # Remplacez par la vraie clé
+
+  - path_regex: secrets/proxmox\.yaml$
+    key_groups:
+      - age:
+          - &proxmox age1yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy  # Remplacez par la vraie clé
+```
+
+**Optionnel mais recommandé** : Ajoutez votre propre clé age pour pouvoir éditer les secrets :
+
+```bash
+# Générer votre clé personnelle
+nix-shell -p age --run "age-keygen -o ~/.config/sops/age/keys.txt"
+# Affichez la clé publique
+grep "public key:" ~/.config/sops/age/keys.txt
+```
+
+Ajoutez votre clé dans `.sops.yaml` :
+```yaml
+creation_rules:
+  - path_regex: secrets/jeremie-web\.yaml$
+    key_groups:
+      - age:
+          - &jeremie-web age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+          - &admin age1zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz  # Votre clé
+```
+
+### Étape 4 : Créer et Chiffrer les Secrets
+
+#### Pour jeremie-web :
+
+```bash
+# 1. Copier le fichier example
+cp secrets/jeremie-web.yaml.example secrets/jeremie-web.yaml
+
+# 2. (Optionnel) Générer un nouveau hash de mot de passe sécurisé
+python3 -c "import crypt; print(crypt.crypt('VotreMotDePasseSecurise', crypt.mksalt(crypt.METHOD_SHA512)))"
+
+# 3. Éditer et chiffrer avec sops
+nix-shell -p sops --run "sops secrets/jeremie-web.yaml"
+# Remplacez le hash du mot de passe par votre nouveau hash (si généré à l'étape 2)
+# Remplacez aussi le token Cloudflare si vous en avez un
+# Sauvegardez et quittez (Ctrl+O, Enter, Ctrl+X dans nano)
+
+# 4. Vérifier que le fichier est bien chiffré
+cat secrets/jeremie-web.yaml | grep "sops:"
+# Si vous voyez "sops: ... mac: ..." alors c'est bon !
+```
+
+#### Pour proxmox :
+
+```bash
+# Même processus
+cp secrets/proxmox.yaml.example secrets/proxmox.yaml
+nix-shell -p sops --run "sops secrets/proxmox.yaml"
+# Remplacez le hash du mot de passe si nécessaire
+# Sauvegardez et quittez
+
+# Vérifier le chiffrement
+cat secrets/proxmox.yaml | grep "sops:"
+```
+
+### Étape 5 : Activer la Configuration sops et Redéployer
+
+Si vous aviez commenté la configuration sops pour le premier déploiement, décommentez-la maintenant :
+
+```nix
+# Dans hosts/jeremie-web/configuration.nix et hosts/proxmox/configuration.nix
+
+# Décommentez la section sops
+sops = {
+  defaultSopsFile = ../../secrets/jeremie-web.yaml;  # ou proxmox.yaml
+  age = {
+    keyFile = "/var/lib/sops-nix/key.txt";
+  };
+  secrets = {
+    jeremie-password-hash = {
+      neededForUsers = true;
+    };
+  };
+};
+
+# Et dans la définition de l'utilisateur
+users.users.jeremie = {
+  isNormalUser = true;
+  createHome = true;
+  home = "/home/jeremie";
+  extraGroups = [ "wheel" ];
+  hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;  # Décommentez
+  # Supprimez ou commentez initialPassword/hashedPassword
+};
+```
+
+Committez et poussez :
+
+```bash
+git add secrets/jeremie-web.yaml secrets/proxmox.yaml
+git add hosts/jeremie-web/configuration.nix hosts/proxmox/configuration.nix
+git commit -m "🔒 Activer sops-nix pour les mots de passe"
+git push
+```
+
+Redéployez sur vos VMs :
+
+```bash
+# Pour jeremie-web
+ssh root@jeremie-web
+cd /etc/nixos
+git pull
+nixos-rebuild switch --flake .#jeremie-web
+
+# Pour proxmox
+ssh root@proxmox
+cd /etc/nixos
+git pull
+nixos-rebuild switch --flake .#proxmox
+```
+
+### Étape 6 : Committer les Secrets (Chiffrés)
+
+Les fichiers de secrets chiffrés peuvent être committés en toute sécurité :
+
+```bash
+# Ajouter avec -f car .gitignore bloque les .yaml par sécurité
+git add -f secrets/jeremie-web.yaml secrets/proxmox.yaml
+git commit -m "🔒 Add encrypted password hashes with sops"
+git push
+```
+
+## 🔄 Modifier un Secret
+
+Pour modifier un secret existant :
+
+```bash
+# Éditer le secret (sops le déchiffre automatiquement pour l'édition)
+nix-shell -p sops --run "sops secrets/jeremie-web.yaml"
+
+# Modifier les valeurs
+# Sauvegarder et quitter
+
+# Committer les changements
+git add secrets/jeremie-web.yaml
+git commit -m "🔒 Update secrets"
+git push
+
+# Redéployer sur la VM
+ssh root@jeremie-web
+cd /etc/nixos
+git pull
+nixos-rebuild switch --flake .#jeremie-web
+```
+
+## 🔑 Changer le Mot de Passe
+
+Pour changer le mot de passe d'un utilisateur :
+
+```bash
+# 1. Générer un nouveau hash
+python3 -c "import crypt; print(crypt.crypt('NouveauMotDePasse', crypt.mksalt(crypt.METHOD_SHA512)))"
+
+# 2. Éditer le secret
+nix-shell -p sops --run "sops secrets/jeremie-web.yaml"
+# Remplacer la valeur de jeremie-password-hash
+
+# 3. Committer et redéployer
+git add secrets/jeremie-web.yaml
+git commit -m "🔒 Update password hash"
+git push
+
+# 4. Redéployer
+ssh root@jeremie-web "cd /etc/nixos && git pull && nixos-rebuild switch --flake .#jeremie-web"
+```
+
+## 📊 Comparaison des Approches
+
+| Approche | Sécurité | Complexité | Cas d'usage |
+|----------|----------|------------|-------------|
+| `initialPassword` | ⚠️ Très faible | ✅ Très simple | Test temporaire uniquement |
+| `password` | ⚠️ Très faible | ✅ Très simple | Jamais en production |
+| `hashedPassword` | ✅ Bon | ✅ Simple | Dev/test, petits projets |
+| `hashedPasswordFile` + sops | 🔒 Excellent | ⚠️ Moyen | **Production (recommandé)** |
+
+## 🆘 Dépannage
+
+### Le fichier secret n'est pas déchiffré au boot
+
+Vérifiez que :
+1. La clé publique dans `.sops.yaml` correspond bien à celle de l'hôte
+2. Le fichier `/var/lib/sops-nix/key.txt` existe sur l'hôte
+3. L'option `neededForUsers = true;` est bien présente dans la configuration du secret
+
+### Je ne peux plus me connecter après le redéploiement
+
+Si vous vous retrouvez bloqué :
+1. Connectez-vous via la console Proxmox (pas SSH)
+2. Réinitialisez le mot de passe manuellement : `passwd jeremie`
+3. Vérifiez la configuration sops et corrigez
+4. Redéployez
+
+### sops ne trouve pas ma clé pour éditer
+
+Si vous avez ajouté votre clé personnelle dans `.sops.yaml` mais sops ne la trouve pas :
+
+```bash
+# Assurez-vous que votre clé est dans le bon répertoire
+export SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt
+nix-shell -p sops --run "sops secrets/jeremie-web.yaml"
+```
+
+## 🎓 Ressources
+
+- [Documentation sops-nix](https://github.com/Mic92/sops-nix)
+- [Guide Age encryption](https://github.com/FiloSottile/age)
+- [NixOS Manual - User Management](https://nixos.org/manual/nixos/stable/index.html#sec-user-management)
+
+## 🎯 Résumé Rapide
+
+**Pour le premier déploiement** :
+1. Utilisez `initialPassword` ou `hashedPassword` temporairement
+2. Déployez et démarrez les VMs
+3. Récupérez les clés publiques des hosts
+4. Mettez à jour `.sops.yaml`
+5. Créez et chiffrez les secrets
+6. Activez la configuration sops
+7. Redéployez avec les secrets chiffrés
+
+**Pour modifier un secret** :
+1. `sops secrets/host.yaml`
+2. Modifiez et sauvegardez
+3. Committez et redéployez
+
+**Sécurité** : 🔒 Ultime avec sops-nix !

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
           inherit system;
           modules = [
             ./hosts/proxmox/configuration.nix
+            sops-nix.nixosModules.sops
           ];
         };
 

--- a/hosts/jeremie-web/configuration.nix
+++ b/hosts/jeremie-web/configuration.nix
@@ -49,10 +49,9 @@
     createHome = true;
     home = "/home/jeremie";
     extraGroups = [ "wheel" ];
-    # Mot de passe initial pour le premier boot (permet de déployer la config)
-    # Utilisé uniquement à la création, jamais réécrit par la suite
-    # Après le premier déploiement, sudo ne demandera plus de mot de passe (wheelNeedsPassword = false)
-    initialPassword = "nixos";
+    # Hash du mot de passe stocké de manière sécurisée dans sops
+    # Le fichier de secrets est chiffré et ne peut être déchiffré que par l'hôte
+    hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
   };
 
   # Root sans mot de passe (SSH root déjà interdit)
@@ -66,19 +65,24 @@
   services.qemuGuest.enable = true;
 
   # Configuration sops-nix pour la gestion des secrets
-# sops = {
-  #   defaultSopsFile = ../../secrets/jeremie-web.yaml;
-  #   age = {
-  #     keyFile = "/var/lib/sops-nix/key.txt";
-  #   };
-  #   secrets = {
-  #     cloudflare-tunnel-token = {
-  #       owner = "cloudflared";
-  #       group = "cloudflared";
-  #       mode = "0400";
-  #     };
-  #   };
-  # };
+  sops = {
+    defaultSopsFile = ../../secrets/jeremie-web.yaml;
+    age = {
+      keyFile = "/var/lib/sops-nix/key.txt";
+    };
+    secrets = {
+      # Hash du mot de passe de l'utilisateur jeremie
+      jeremie-password-hash = {
+        neededForUsers = true;
+      };
+      # Token Cloudflare Tunnel (optionnel, décommenter si utilisé)
+      # cloudflare-tunnel-token = {
+      #   owner = "cloudflared";
+      #   group = "cloudflared";
+      #   mode = "0400";
+      # };
+    };
+  };
 
   # Configuration du site j12zdotcom
   # Le module sera importé via flake.nix

--- a/hosts/proxmox/configuration.nix
+++ b/hosts/proxmox/configuration.nix
@@ -55,13 +55,15 @@
   #   ];
   # };
 
-  # Si tu utilises l’Option A, définis tout de même l’utilisateur :
+  # Si tu utilises l'Option A, définis tout de même l'utilisateur :
   users.users.jeremie = {
     isNormalUser = true;
     createHome = true;
     home = "/home/jeremie";
     extraGroups = [ "wheel" ];
-    hashedPassword = "$6$vwZmaAkvi9Sjgv60$HVIr50fg9sFmFrgJ7CCtEhey0m7OBLepLDWAa1PcdZSX3WrK24DWs48IQpHi85u4yYwjG0xHwC4waXzb3IqLB1";
+    # Hash du mot de passe stocké de manière sécurisée dans sops
+    # Le fichier de secrets est chiffré et ne peut être déchiffré que par l'hôte
+    hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
   };
 
   # Root sans mot de passe (SSH root déjà interdit)
@@ -73,6 +75,20 @@
 
   # QEMU Guest Agent
   services.qemuGuest.enable = true;
+
+  # Configuration sops-nix pour la gestion des secrets
+  sops = {
+    defaultSopsFile = ../../secrets/proxmox.yaml;
+    age = {
+      keyFile = "/var/lib/sops-nix/key.txt";
+    };
+    secrets = {
+      # Hash du mot de passe de l'utilisateur jeremie
+      jeremie-password-hash = {
+        neededForUsers = true;
+      };
+    };
+  };
 
   # Paquets utiles
   environment.systemPackages = with pkgs; [ vim git curl wget htop ];

--- a/secrets/jeremie-web.yaml
+++ b/secrets/jeremie-web.yaml
@@ -1,0 +1,39 @@
+#ENC[AES256_GCM,data:JNrp7qjnHmpXjY4dqtjzrSlwV/Vs+tc0XLHzISYbUNhbfcPRMDmItNADxt+wcd0=,iv:/rxDYxL+8OE41oQzomGqSfxepdjZOXkaQE+iKSLyDS4=,tag:rAMeREKFCLFHfskQbyaryg==,type:comment]
+#ENC[AES256_GCM,data:zr7M4OMEuuytjNI64376a1JBnso/o9d9J24p2okNGOrFtQ03dm5/GHrBvEJBgOCr0MezpzMbEUObKbjxmr/uw/dAKhgYsaM=,iv:jh2kGL8FkeNSA6aRdcPRFthkwTniUQXcM6hMz6ZwK/8=,tag:Selzx2p2ywsTHfhNdLiOEg==,type:comment]
+#
+#ENC[AES256_GCM,data:jKIvv/JUNPJMuST79VxDKWMIQqfUK4MuuQP8QxtLD5CshDW9cDkSmz1FvDXRRRXUF9Etc3O50FuVpWO07udZ6//h,iv:Im0kYlPkVgFIwf652WEUgbqi9memUU5qLSwRbRjOzX0=,tag:3/ujcJ82ui3CwI7Azs15oA==,type:comment]
+#ENC[AES256_GCM,data:HWj9F1+TXyF58xhj8cWyc5Z39tmlLr3S7fJk4DJpHdpROlcR5gJp5PQn+fvwBg==,iv:aFn6WGJqOoNKlB6y31JLsTsYRgUlG/ZTve0hZ+Zxutk=,tag:5PYxGdtEiWce4ylVnzVkLQ==,type:comment]
+#
+#ENC[AES256_GCM,data:4b28HEs2PhmshscTLAKFQp8zRXAZOz9vq7bp0fXAthmSEt+WantQQM9MkIcKIlM=,iv:AP+aUdyQU6KxaRpoy6yk46n7kWlCVsW0smBrKIhGlBQ=,tag:SMd1sNDUPLi7dQuT6ukiag==,type:comment]
+#ENC[AES256_GCM,data:4DODzxcMQ2Fr+JYk9bosu5PDNYvE1hfJSoBHzRYFp3KP9vm5t+Eb3lx1u1UagMjTuAO5k4Bi29npAEkRoaP45Wy3WuJGqEGoSH7A/IyA5B1mX6E=,iv:iX4wUMAaZopqESbZefaSK7BdkqrkpFFNChAmLsv3Qp8=,tag:TKY+wkFzZTqYJE6bF5VVBA==,type:comment]
+#ENC[AES256_GCM,data:xzxHPD13ocukvDOPhaEtAtQxCEhv6lEI0teVM2Zsgfc6fXB+XXj3TWvHg67PEMuzQDobow==,iv:U4IAE5WOZeMZRDCEOLjZMXrPG5+f8TRpmZdFbOzOe6o=,tag:eXxBk8eg5qiPGDozvZzoBg==,type:comment]
+#ENC[AES256_GCM,data:dmwYr9OjSCpQzCR3uOIS5kgrpq28e3X3g3zw/OhPEq8Q4mol0eczvKJNtpeO1QDy,iv:rlDy3yUSgT/kW9Spueb8DHUiKX+Xc22ByW3HO486RSg=,tag:tPdS+sth1qynrl0uMLWzNw==,type:comment]
+#
+#ENC[AES256_GCM,data:+Vp+ViK/oWaxoInHLw0mxQnoknCBA22gOtFfgHwqeknGYkejdqqdMxyUraYj/IjTuFng/vbkSurgSonaVl+TNb1xKUtPCQFl0yNFpSTHua2mlYk5yZxmrNUqfMU3A2s=,iv:yALUlzg5G/SHZLr4nZog8nlts12R6GFou3sykOExlUQ=,tag:bVh7Zj/HVi4Q5t8CEnlG7g==,type:comment]
+#ENC[AES256_GCM,data:0JKa3V476F0LTQMGNEBy1KAZZ/x1U/m9fyIH4xsZSRYUWCu0TE7iQibiAXh0NVnl67zLEHAFPycgWORog8PbjhVEpV1P+Q==,iv:PUmNjouTsth9Gmf2v4kCO5jJtXdvshw92sVRg5wlUCU=,tag:9hJhZBs3TVGT+MXZYqRsgw==,type:comment]
+#ENC[AES256_GCM,data:Y5LGrCl/RUW6qxhVVPIB5IBl7zSrwOFUUe4d50cEiM1aStjmpUPN1k8D++1ZG3D/sXR0s1xtMtPnITQdxD4VHxqrSRLVgG5rvEvCY8/LME/0Te0zEsg=,iv:TFaQ6TvcRUJJmm52opssYvOpcF5lxZWN2CimmVZqxp4=,tag:udfpx7ltR8HY9ixlebyeZA==,type:comment]
+#ENC[AES256_GCM,data:kxnrIIobo8r7MLPffhCZyp+NYgCtZUqVvcwh8P4gbR95BJdzw/NQgmmLw6oIXnI0a7uEz4NyF2EQGTr3KWurOo2MQjFe3/KeRvaRPaukEI0+P76TB0S0qc5a,iv:ATz78ZO99s1I4vBqWvHGEZu14CGE8uRap13HZbLdU5I=,tag:UyNtV0LqVAQwryGU6CdaHw==,type:comment]
+#ENC[AES256_GCM,data:Mfs6fDy7e2Cz/8VZe8cVCS5QrQv/M3JYo8OP/dXF48HYGfE3an4NJQXt41EDEC9+j6QnIkv3ayW0d0YehY5WpVf1C4M=,iv:jko9zB+iw+d4XGNUVqEP68YxfvYAcgcLD4rdiPzY7BA=,tag:0e8g4XCTZZqDLM9X6+KAPg==,type:comment]
+jeremie-password-hash: ENC[AES256_GCM,data:hPaJDOplDsnUz301J98oYq7uk1CqGE2qbDh7Ore0lwtQ1ZMeKgPHnNoVZT4u13DJ+auTPQ8FHRL0BaFBJcn5EUa/fIavQrpfYfDF+frOPRucbgbq+lsh5Sz2qW78WKU9h1NTMPt8FmfByg==,iv:TpS9TN1HqTYyUfsu06aNRiXUdLqFN0JfkpABujiG3Dk=,tag:k5LguvdLNurmSTH2NbKGZQ==,type:str]
+#ENC[AES256_GCM,data:IVVMQGspbiM5lVukVmlYtprHnpOQRAkr9I4/ATfKgSq+vWlpdamajgerlBnNHe98bRlrdOOEr//7JDL2OolWT0Y6r899ncLK,iv:M+uktljLle+K6AE8iCDKrvOSZ/BlTWVDQ+TdhdADJ2A=,tag:m1glRS9+mBjpjBsxH4J9XQ==,type:comment]
+#ENC[AES256_GCM,data:xv7ZntadY/T4RZHdrT/5/dfsJopR9l5HbMsTcEUqGBMy8dwPS5aUbEf3OguozS5XMFptPVdh76DbJ3Y=,iv:Y/ftFZb6CXVNn+ntEpeQEKksE8UlEmSv5VPLLASFS4Y=,tag:neO4H5yGqFsNUzsIN/yAzg==,type:comment]
+#ENC[AES256_GCM,data:AVXrJVEDAw8bbC/Xw/5cjo8b44jZ6pghr5p7f3uyBfqnNs3IHgZf6Ggkc7VccIxPPRBYAfxloLVcQbrCFsLkiSXiHJpygd59OlMQ9IsHgZzw7EygGNyb8WcVjam9,iv:NiD9gAN7sM6nZzPQ89GpaXwVoeu9J0hy3HTnLmvRx4U=,tag:W1bQL82RBxkr3caRx4eHZw==,type:comment]
+cloudflare-tunnel-token: ENC[AES256_GCM,data:yCs6iItSGKnbyLpjYdJQ3OfvMIQLp/c/SuasFFd0ZPeXVMzpb+sXs+Os9MEyMMAd9YSxv4yboXS2fZnXfoi/xvcSfyfcJeZ7L+CehhtNJ2K717wJ3s0U8Zz8A6PbumrwXvSZboOSxRf59D5yP0lbrmpzkkI75Ag/cmNAhdrd9SPpFxlsS149yaMr+8V577/wrHGovgQ/OOsHdfzbCioTyieTs1ux8T1XBc2WcKsn4CqgmK6i+Zrfww==,iv:owKsQHHDXxjeEx4HHidL+e3vXLnzeyO2KTe3YnZ40pU=,tag:Mjx4XJoBiYKDogN+ihhGqw==,type:str]
+#ENC[AES256_GCM,data:x7fMtgJ58bP7Bp2UwXxGddGMcBNCkPVqrL2bKnadcWY7gIKU9zCRixFP,iv:9U/XBm8oK0EVPHH+2qBUGaySlRM44zNYkcG0s1aHBCs=,tag:VkKU6Ei67O9aZ/Ego8hWbw==,type:comment]
+#ENC[AES256_GCM,data:AVguPpzE7dWL,iv:HZVCHSEmcfyDdtSkeUnZPnJa+2DLILP56B3jz05v2PQ=,tag:Bxh/5jqvsf/m/YMiYBxvIA==,type:comment]
+#ENC[AES256_GCM,data:7SZgNz0Nt7xgdl5JjlIt4yrmNvyEpmgzGeenDg==,iv:Ow+hF/siTge+FwUsmOOuQvXnoUl9+OtzquJAynG7kkU=,tag:vSap3g3KqDpiOEY/hVPx8w==,type:comment]
+sops:
+    age:
+        - recipient: age1nt3ly627s6eqcv97zyw3n489gh7nt2jlrq6mfhucct8wq4lgku6saynhhw
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnTmhPQWV0aEk4NGFGaTlv
+            SUdzbytJY0RaUkd0eHBIVFREMXA1UWE0eVRnClIvMUd3dTAzYXZPN1FyR3kxQ1FY
+            NDVaTDVBbTZlOWVaSm5ZektBNVpiNmMKLS0tIGtPSi94YUJJQ3ZBWjJ5bUw2Vk81
+            elk2N2Yvd3JOczF4bkxjZHc0VWJQMjgKLIfl/kEB9o85oj8Ndx8+QNT5nzArLXgc
+            QUFiTaA5nppVitVWsbGetVGRVMYc2lfSgpeg8kF1AWUCjW9MtePnIw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-11-09T18:46:05Z"
+    mac: ENC[AES256_GCM,data:eTYnzz0qeqFhxJGw2wqClrFd0dRTUcezulW22/aKFolMpcEXxQYyuH/sW5OnhLKmk+nieQO+6IXT8sLax3/EE8GE5b/pah+XKHIv/Qo/i8AVN7sZLalTE7jVyFmcjmBVqIUt1oPnP75vhG7VedCvM8Nlm4xtZHBGOlmYvkrS5O8=,iv:MRY9aSWqH8a1FClNnj+QSgFs2ybxyE55HHjsZawSQ0M=,tag:1RtWklnjIoYJXqmCszBPZg==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/secrets/proxmox.yaml.example
+++ b/secrets/proxmox.yaml.example
@@ -1,27 +1,22 @@
-# Exemple de fichier de secrets pour jeremie-web
-# Copier ce fichier en secrets/jeremie-web.yaml et le chiffrer avec sops
+# Exemple de fichier de secrets pour proxmox
+# Copier ce fichier en secrets/proxmox.yaml et le chiffrer avec sops
 #
 # IMPORTANT: Ce fichier doit être chiffré avant de le committer !
 # NE JAMAIS COMMITTER LE FICHIER NON CHIFFRÉ !
 #
 # Pour créer et chiffrer le fichier de secrets:
-# 1. Copier ce fichier: cp secrets/jeremie-web.yaml.example secrets/jeremie-web.yaml
-# 2. Éditer avec sops: sops secrets/jeremie-web.yaml
+# 1. Copier ce fichier: cp secrets/proxmox.yaml.example secrets/proxmox.yaml
+# 2. Éditer avec sops: sops secrets/proxmox.yaml
 # 3. Remplacer les valeurs avec vos vrais secrets
 #
 # IMPORTANT: Vous devez d'abord mettre à jour .sops.yaml avec la vraie clé publique de l'hôte
-# Obtenir la clé: ssh root@jeremie-web "cat /var/lib/sops-nix/key.pub"
+# Obtenir la clé: ssh root@proxmox "cat /var/lib/sops-nix/key.pub"
 
 # Hash du mot de passe pour l'utilisateur jeremie (généré avec: mkpasswd -m sha-512)
 # Le hash peut être dans un repo public car il est impossible de retrouver le mot de passe
 # Mais avec sops, on chiffre quand même pour une sécurité maximale
 jeremie-password-hash: $6$g/9Fke6IjYVALC5S$.uMMuJpIgro1MxwzBtvBMG7G2pP88ulMtl91kPWdg3nEuE3uigDQ164yqvtEEGKiFtuN8RaFok66AiIIwErvq1
 
-# Token Cloudflare Tunnel (optionnel, si vous utilisez Cloudflare Tunnel)
-# Le token se trouve dans votre dashboard Cloudflare Tunnel:
-# https://one.dash.cloudflare.com/ → Access → Tunnels → Configure → Installation token
-cloudflare-tunnel-token: eyJhIjoiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...
-
 # Autres secrets peuvent être ajoutés ici
 # exemple:
-# api-key: mon-api-key-secret
+# vpn-key: ma-clé-vpn-secrète


### PR DESCRIPTION
## Changements de sécurité

### Problème résolu
- ❌ Mot de passe en clair dans jeremie-web (initialPassword = "nixos")
- ❌ Hash de mot de passe en clair dans proxmox
- ⚠️ Risque de sécurité pour un repo public

### Solution implémentée
- ✅ Configuration sops-nix pour les deux hosts (jeremie-web + proxmox)
- ✅ Utilisation de hashedPasswordFile au lieu de initialPassword/hashedPassword
- ✅ Hash de mot de passe chiffré avec sops-nix
- ✅ Sécurité maximale : seul l'hôte peut déchiffrer son secret

## Modifications

### Infrastructure sops
- `.sops.yaml` : Ajout de la configuration pour proxmox
- `flake.nix` : Activation de sops-nix.nixosModules.sops pour proxmox
- `secrets/proxmox.yaml.example` : Nouveau fichier template pour proxmox
- `secrets/jeremie-web.yaml.example` : Ajout du champ jeremie-password-hash

### Configuration des hosts
- `hosts/jeremie-web/configuration.nix` :
  - Activation de la configuration sops (décommentée)
  - Remplacement de initialPassword par hashedPasswordFile
  - Ajout du secret jeremie-password-hash avec neededForUsers = true

- `hosts/proxmox/configuration.nix` :
  - Ajout de la configuration sops
  - Remplacement de hashedPassword par hashedPasswordFile
  - Ajout du secret jeremie-password-hash avec neededForUsers = true

### Documentation
- `docs/SECURE-PASSWORDS.md` : Guide complet pour :
  - Comprendre les différentes approches de gestion des mots de passe
  - Déployer avec sops-nix (premier boot + configuration)
  - Récupérer les clés publiques des hosts
  - Créer et chiffrer les secrets
  - Modifier les secrets existants
  - Dépannage

## Prochaines étapes

Pour activer complètement la solution, il faut :

1. **Premier déploiement** (si les VMs ne sont pas encore créées) :
   - Utiliser temporairement initialPassword ou hashedPassword
   - Déployer les VMs

2. **Récupérer les clés publiques** : ```bash ssh root@jeremie-web "cat /var/lib/sops-nix/key.pub" ssh root@proxmox "cat /var/lib/sops-nix/key.pub" ```

3. **Mettre à jour .sops.yaml** avec les vraies clés

4. **Créer et chiffrer les secrets** : ```bash cp secrets/jeremie-web.yaml.example secrets/jeremie-web.yaml sops secrets/jeremie-web.yaml # Idem pour proxmox ```

5. **Redéployer** avec les secrets chiffrés

Voir `docs/SECURE-PASSWORDS.md` pour le guide complet.

## Sécurité

- 🔒 Hash de mot de passe chiffré (impossible à voir dans le repo)
- 🔒 Déchiffrement uniquement par l'hôte concerné
- 🔒 Approche recommandée pour la production
- ✅ Conforme aux bonnes pratiques de sécurité NixOS