### PR TITLE
Set up minimal ISO builder with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Ce repository contient ma configuration NixOS déclarative pour gérer plusieurs
 - 🔑 **Authentification SSH par clés uniquement** (pas de mots de passe)
 - 📦 **Multi-hôtes** avec configuration centralisée
 - 🔄 **Infrastructure as Code** avec historique Git complet
+- 💿 **ISO minimale personnalisée** avec support console série pour Proxmox/NoVNC
 - 📚 **Documentation détaillée** en français
 
 ## 🖥️ Hôtes configurés
@@ -34,6 +35,25 @@ Serveur web avec fonctionnalités avancées.
 - Configuration Git globale
 - Sudo sans mot de passe
 - QEMU Guest Agent
+
+## 💿 ISO personnalisée
+
+Une ISO NixOS minimale optimisée pour Proxmox/NoVNC avec :
+
+- ✅ **Console série (ttyS0)** activée automatiquement
+- ✅ **Environnement X11 minimal** (xterm + twm)
+- ✅ **ZSH + Starship** pour un shell moderne
+- ✅ **Autologin** (utilisateur `nixos`)
+- ✅ **SSH et réseau DHCP** préconfigurés
+
+**Builder l'ISO :**
+```bash
+cd iso/
+nix build .#nixosConfigurations.iso-minimal-ttyS0.config.system.build.isoImage
+# L'ISO se trouve dans : result/iso/nixos-minimal-ttyS0.iso
+```
+
+📖 **Guide complet :** [docs/ISO-BUILDER.md](docs/ISO-BUILDER.md)
 
 ## 🚀 Démarrage rapide
 
@@ -69,23 +89,25 @@ nix-config/
 │   └── jeremie-web/
 │       ├── configuration.nix
 │       └── hardware-configuration.nix
+├── iso/                         # Configuration ISO personnalisée
+│   └── flake.nix                # Builder ISO minimale avec TTY série
 ├── secrets/                     # Gestion des secrets chiffrés
 │   ├── README.md
 │   ├── .sops.yaml
 │   └── *.yaml                   # Fichiers de secrets chiffrés
 └── docs/                        # Documentation complète
-    ├── README.md                # Introduction au projet
     ├── BOOTSTRAP.md             # Guide d'initialisation des VMs
-    └── SECRETS.md               # Gestion des secrets avec SOPS
+    ├── SECRETS.md               # Gestion des secrets avec SOPS
+    └── ISO-BUILDER.md           # Guide de construction d'ISO personnalisée
 ```
 
 ## 📖 Documentation
 
 Pour plus d'informations, consultez la documentation dans le dossier `docs/` :
 
-- **[docs/README.md](docs/README.md)** - Introduction détaillée au projet
 - **[docs/BOOTSTRAP.md](docs/BOOTSTRAP.md)** - Guide complet pour initialiser une nouvelle VM
 - **[docs/SECRETS.md](docs/SECRETS.md)** - Gestion et rotation des clés de chiffrement
+- **[docs/ISO-BUILDER.md](docs/ISO-BUILDER.md)** - Builder une ISO NixOS personnalisée pour Proxmox
 
 ## 🔐 Gestion des secrets
 

--- a/docs/ISO-BUILDER.md
+++ b/docs/ISO-BUILDER.md
@@ -1,0 +1,467 @@
+# 💿 Builder une ISO NixOS minimale pour Proxmox/NoVNC
+
+Ce guide détaille comment générer et utiliser une ISO NixOS minimale personnalisée avec support de la console série (ttyS0), optimisée pour une utilisation dans Proxmox avec NoVNC.
+
+## 📋 Table des matières
+
+- [Vue d'ensemble](#-vue-densemble)
+- [Prérequis](#-prérequis)
+- [Construction de l'ISO](#-construction-de-liso)
+  - [Depuis une VM NixOS](#depuis-une-vm-nixos)
+  - [Depuis un système NixOS local](#depuis-un-système-nixos-local)
+- [Utilisation de l'ISO](#-utilisation-de-liso)
+- [Détails techniques](#-détails-techniques)
+- [Personnalisation](#-personnalisation)
+- [Dépannage](#-dépannage)
+
+---
+
+## 🎯 Vue d'ensemble
+
+Cette ISO personnalisée résout un problème courant lors de l'utilisation de NixOS dans Proxmox avec NoVNC : **l'accès à un terminal fonctionnel dès le boot**.
+
+### Le problème
+
+Quand vous démarrez l'ISO NixOS standard en mode graphique sous Proxmox/NoVNC :
+- Le framebuffer VGA affiche une console graphique "muette"
+- Il n'y a pas de TTY actif utilisable
+- Des outils comme `xterm` ne fonctionnent pas correctement
+
+### La solution
+
+En activant la **console série (ttyS0)** dès le boot avec le paramètre `console=ttyS0,115200n8` :
+- Le noyau Linux redirige toute la console système vers le port série
+- systemd démarre un getty sur ce terminal série
+- NoVNC ou la console Proxmox voit un **terminal texte réel** (lié à `/dev/ttyS0`)
+- Les outils comme `xterm` peuvent s'attacher à un vrai TTY
+
+### Caractéristiques de l'ISO
+
+✅ **Console série active automatiquement** (ttyS0 à 115200 baud)
+✅ **Autologin** en tant qu'utilisateur `nixos`
+✅ **Environnement X11 minimal** avec `xterm` et `twm`
+✅ **ZSH + Starship** pour un shell moderne
+✅ **Outils de base** : vim, git, curl, wget, htop, tree
+✅ **SSH activé** avec authentification par mot de passe (pour debug)
+✅ **Réseau DHCP** configuré automatiquement
+
+---
+
+## 🔧 Prérequis
+
+### Pour builder l'ISO
+
+Vous aurez besoin :
+
+1. **NixOS avec flakes activés** (version 23.05 ou plus récente)
+2. **Espace disque suffisant** (~5 GB pour le build)
+3. **Accès internet** pour télécharger les dépendances
+4. **Ce repository** cloné localement
+
+### Activer les flakes (si nécessaire)
+
+Si les flakes ne sont pas encore activés sur votre système :
+
+```bash
+# Créer ou éditer /etc/nixos/configuration.nix
+nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
+# Reconstruire le système
+sudo nixos-rebuild switch
+```
+
+Ou utilisez temporairement les flakes sans les activer globalement :
+
+```bash
+export NIX_CONFIG="experimental-features = nix-command flakes"
+```
+
+---
+
+## 🏗️ Construction de l'ISO
+
+### Depuis une VM NixOS
+
+C'est la méthode recommandée si vous travaillez déjà dans Proxmox.
+
+#### 1. Créer une VM NixOS temporaire
+
+Dans Proxmox :
+1. Téléchargez l'ISO NixOS standard : [nixos.org/download](https://nixos.org/download)
+2. Créez une nouvelle VM avec :
+   - **CPU** : 4 cores minimum
+   - **RAM** : 8 GB minimum
+   - **Disque** : 20 GB minimum
+   - **Réseau** : Bridge ou NAT avec accès internet
+
+#### 2. Installer NixOS dans la VM
+
+Bootez sur l'ISO et suivez l'installation minimale :
+
+```bash
+# 1. Partitionner le disque (exemple simple avec tout sur une partition)
+sudo parted /dev/sda -- mklabel gpt
+sudo parted /dev/sda -- mkpart primary 1MiB 100%
+sudo mkfs.ext4 -L nixos /dev/sda1
+
+# 2. Monter et préparer
+sudo mount /dev/disk/by-label/nixos /mnt
+sudo nixos-generate-config --root /mnt
+
+# 3. Éditer la configuration pour activer les flakes
+sudo nano /mnt/etc/nixos/configuration.nix
+# Ajouter : nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
+# 4. Installer
+sudo nixos-install
+
+# 5. Redémarrer
+sudo reboot
+```
+
+#### 3. Cloner ce repository
+
+Une fois NixOS installé et redémarré :
+
+```bash
+# Installer git si nécessaire
+nix-shell -p git
+
+# Cloner le repo
+git clone https://github.com/JeremieAlcaraz/nix-config.git
+cd nix-config/iso
+```
+
+#### 4. Builder l'ISO
+
+```bash
+# Se placer dans le dossier iso/
+cd ~/nix-config/iso
+
+# Builder l'ISO (prend 10-30 minutes selon la machine)
+nix build .#nixosConfigurations.iso-minimal-ttyS0.config.system.build.isoImage
+```
+
+Le build va :
+1. Télécharger toutes les dépendances NixOS nécessaires
+2. Construire l'image ISO personnalisée
+3. Créer un lien symbolique `result` pointant vers l'ISO
+
+#### 5. Récupérer l'ISO
+
+L'ISO se trouve dans :
+
+```bash
+ls -lh result/iso/*.iso
+# Exemple : result/iso/nixos-minimal-ttyS0.iso
+```
+
+Pour la copier ailleurs :
+
+```bash
+# Copier vers un dossier accessible
+cp result/iso/nixos-minimal-ttyS0.iso ~/
+
+# Ou directement vers un serveur via SCP
+scp result/iso/nixos-minimal-ttyS0.iso user@server:/path/to/destination/
+```
+
+#### 6. Télécharger l'ISO depuis Proxmox
+
+Depuis l'interface web Proxmox, vous pouvez :
+
+**Option A : Via SCP/SFTP**
+```bash
+# Depuis un autre système, récupérer l'ISO
+scp root@vm-nixos-builder:~/nix-config/iso/result/iso/*.iso ./
+```
+
+**Option B : Upload direct dans Proxmox**
+1. Allez dans **Datacenter > Storage > local**
+2. Cliquez sur **ISO Images**
+3. Uploadez l'ISO depuis votre machine locale
+
+---
+
+### Depuis un système NixOS local
+
+Si vous avez déjà NixOS sur votre machine :
+
+```bash
+# 1. Cloner le repo
+git clone https://github.com/JeremieAlcaraz/nix-config.git
+cd nix-config/iso
+
+# 2. Builder l'ISO
+nix build .#nixosConfigurations.iso-minimal-ttyS0.config.system.build.isoImage
+
+# 3. L'ISO est dans result/iso/
+ls -lh result/iso/
+```
+
+---
+
+## 🚀 Utilisation de l'ISO
+
+### 1. Upload dans Proxmox
+
+1. Connectez-vous à l'interface web Proxmox
+2. Allez dans **Datacenter > [votre-node] > local (pve)**
+3. Onglet **ISO Images**
+4. Cliquez **Upload** et sélectionnez votre ISO
+
+### 2. Créer une VM de test
+
+```bash
+# Exemple de création de VM via CLI Proxmox
+qm create 999 \
+  --name test-iso-nixos \
+  --memory 2048 \
+  --cores 2 \
+  --net0 virtio,bridge=vmbr0 \
+  --cdrom local:iso/nixos-minimal-ttyS0.iso \
+  --boot order=cdrom
+
+# Démarrer la VM
+qm start 999
+```
+
+Ou via l'interface web :
+1. Clic droit sur le nœud > **Create VM**
+2. Configurez la VM
+3. Dans **OS**, sélectionnez votre ISO personnalisée
+4. Terminez la création et démarrez
+
+### 3. Accéder à la console
+
+#### Via NoVNC (interface web)
+
+1. Sélectionnez votre VM dans l'interface Proxmox
+2. Cliquez sur **Console** (bouton en haut)
+3. Vous devriez voir le boot automatique avec TTY série actif
+
+#### Via console série (recommandé)
+
+```bash
+# Depuis le shell Proxmox
+qm terminal 999
+```
+
+### 4. Utiliser l'ISO
+
+Une fois bootée, vous êtes automatiquement connecté en tant qu'utilisateur `nixos`.
+
+**Démarrer l'interface graphique :**
+```bash
+startx
+```
+
+Cela lance :
+- `twm` (Tiny Window Manager)
+- `xterm` (terminal graphique)
+
+**Installer NixOS :**
+```bash
+# L'ISO contient tous les outils d'installation standard
+sudo nixos-install
+```
+
+---
+
+## 🔬 Détails techniques
+
+### Paramètres de boot
+
+```nix
+boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty1" ];
+```
+
+- **`console=ttyS0,115200n8`** :
+  - `ttyS0` : premier port série
+  - `115200` : vitesse en bauds (standard pour les consoles modernes)
+  - `n8` : No parity, 8 bits (configuration série standard)
+
+- **`console=tty1`** :
+  - Garde aussi la console VGA/graphique standard active
+  - Permet d'utiliser l'ISO sur du matériel physique sans port série
+
+### Architecture de l'ISO
+
+```
+ISO NixOS personnalisée
+├── Kernel Linux avec params série
+├── initrd avec drivers série
+├── Système de base NixOS
+│   ├── Getty sur ttyS0 (autologin: nixos)
+│   ├── Getty sur tty1
+│   └── Getty sur tty2
+├── Environnement X11
+│   ├── xterm
+│   ├── twm (window manager)
+│   └── xinit
+└── Outils supplémentaires
+    ├── ZSH + Starship
+    ├── vim, git, curl, wget
+    └── SSH server
+```
+
+### Comparaison : ISO standard vs personnalisée
+
+| Aspect | ISO standard | ISO personnalisée |
+|--------|-------------|-------------------|
+| Console série | ❌ Désactivée par défaut | ✅ Active dès le boot |
+| TTY utilisable dans NoVNC | ⚠️ Nécessite menu GRUB | ✅ Automatique |
+| Autologin | ❌ Login manuel | ✅ User `nixos` auto |
+| Shell | Bash basique | ZSH + Starship |
+| Interface graphique | Aucune | xterm + twm |
+| Taille ISO | ~800 MB | ~950 MB |
+
+---
+
+## 🎨 Personnalisation
+
+Le fichier `iso/flake.nix` est entièrement modulable.
+
+### Ajouter des packages
+
+```nix
+environment.systemPackages = with pkgs; [
+  # Vos packages personnalisés
+  tmux
+  neovim
+  ranger
+  # ...
+];
+```
+
+### Changer le shell par défaut
+
+```nix
+users.users.nixos = {
+  shell = pkgs.bash;  # ou pkgs.fish, pkgs.zsh, etc.
+};
+```
+
+### Activer des services supplémentaires
+
+```nix
+# Exemple : Tailscale pour VPN automatique
+services.tailscale.enable = true;
+```
+
+### Changer le nom de l'ISO
+
+```nix
+isoImage = {
+  isoName = "mon-iso-custom.iso";
+  volumeID = "MY_CUSTOM_ISO";
+  appendToMenuLabel = " (Ma config perso)";
+};
+```
+
+### Rebuild après modification
+
+```bash
+# Rebuild après changements
+nix build .#nixosConfigurations.iso-minimal-ttyS0.config.system.build.isoImage
+
+# Vérifier la nouvelle ISO
+ls -lh result/iso/
+```
+
+---
+
+## 🛠️ Dépannage
+
+### Le build échoue avec "out of disk space"
+
+**Solution** : Libérez de l'espace ou utilisez un disque plus grand
+
+```bash
+# Nettoyer le store Nix
+nix-collect-garbage -d
+
+# Vérifier l'espace libre
+df -h /nix
+```
+
+### Le build est très lent
+
+**Solution** : Augmentez les ressources de la VM
+
+- **CPU** : Passez à 4-6 cores
+- **RAM** : Augmentez à 8-16 GB
+
+### L'ISO ne boot pas dans Proxmox
+
+**Vérifiez** :
+
+1. La VM est configurée en **BIOS** (pas UEFI) ou l'inverse selon votre config
+2. L'ordre de boot inclut bien le CD-ROM
+3. L'ISO n'est pas corrompue :
+   ```bash
+   sha256sum result/iso/*.iso
+   ```
+
+### xterm ne se lance pas après startx
+
+**Cause probable** : Problème X11
+
+**Debug** :
+```bash
+# Vérifier les logs X
+cat ~/.local/share/xorg/Xorg.0.log
+
+# Tester manuellement
+startx -- :1
+```
+
+### SSH ne fonctionne pas
+
+**Vérifiez** :
+
+```bash
+# Le service est actif
+systemctl status sshd
+
+# Le port est ouvert
+ss -tlnp | grep 22
+
+# Firewall Proxmox
+# (depuis l'hôte Proxmox)
+iptables -L -n | grep 22
+```
+
+### Je n'ai pas accès réseau
+
+**Solution** :
+
+```bash
+# Vérifier les interfaces
+ip addr
+
+# Redémarrer NetworkManager
+sudo systemctl restart NetworkManager
+
+# Debug DHCP
+sudo dhclient -v
+```
+
+---
+
+## 📚 Ressources additionnelles
+
+- [NixOS Manual - Building ISO Images](https://nixos.org/manual/nixos/stable/#sec-building-image)
+- [NixOS Wiki - ISO Image](https://nixos.wiki/wiki/Creating_a_NixOS_live_CD)
+- [Proxmox VE Documentation](https://pve.proxmox.com/pve-docs/)
+- [Serial Console Linux HOWTO](https://tldp.org/HOWTO/Serial-Console-HOWTO/)
+
+---
+
+## 🤝 Contribution
+
+Des suggestions pour améliorer cette ISO ou ce guide ? N'hésite pas à ouvrir une issue ou une PR !
+
+---
+
+**Note** : Cette ISO est conçue pour un usage de développement et de test. Pour un usage en production, désactive l'authentification SSH par mot de passe et configure des clés SSH appropriées.

--- a/iso/.gitignore
+++ b/iso/.gitignore
@@ -1,0 +1,7 @@
+# Build results
+result
+result-*
+
+# Nix build artifacts
+*.iso
+*.qcow2

--- a/iso/README.md
+++ b/iso/README.md
@@ -1,0 +1,84 @@
+# 💿 ISO NixOS minimale pour Proxmox/NoVNC
+
+Ce dossier contient la configuration pour générer une ISO NixOS personnalisée avec support de la console série (ttyS0), optimisée pour Proxmox et NoVNC.
+
+## 🎯 Pourquoi cette ISO ?
+
+L'ISO standard NixOS ne configure pas la console série par défaut, ce qui rend l'utilisation dans Proxmox/NoVNC problématique. Cette ISO personnalisée résout ce problème en activant `ttyS0` dès le boot.
+
+## 🚀 Utilisation rapide
+
+### Builder l'ISO
+
+```bash
+# Depuis ce dossier
+nix build .#nixosConfigurations.iso-minimal-ttyS0.config.system.build.isoImage
+
+# L'ISO sera disponible dans
+ls -lh result/iso/
+```
+
+### Caractéristiques de l'ISO
+
+- ✅ Console série (ttyS0) active automatiquement
+- ✅ Autologin utilisateur `nixos`
+- ✅ ZSH + Starship comme shell
+- ✅ Environnement X11 minimal (xterm + twm)
+- ✅ SSH activé avec mot de passe (user: nixos, pass: nixos)
+- ✅ Réseau DHCP automatique
+- ✅ Outils de base : vim, git, curl, wget, htop, tree
+
+## 📖 Documentation complète
+
+Pour un guide détaillé avec instructions pas-à-pas depuis une VM, consultez :
+
+**[../docs/ISO-BUILDER.md](../docs/ISO-BUILDER.md)**
+
+## 🎨 Personnalisation
+
+Le fichier `flake.nix` est entièrement modulable. Vous pouvez :
+
+- Ajouter des packages dans `environment.systemPackages`
+- Changer le shell par défaut
+- Activer des services supplémentaires
+- Modifier le nom de l'ISO dans `isoImage`
+
+Après modification, rebuildez simplement avec la même commande.
+
+## 📦 Résultat
+
+L'ISO générée pèse environ **950 MB** et contient tout le nécessaire pour :
+
+- Installer NixOS sur une nouvelle machine
+- Tester une configuration
+- Faire du rescue/debugging
+- Utiliser comme live USB avec persistance
+
+## 🔬 Détails techniques
+
+### Paramètres de boot
+
+```nix
+boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty1" ];
+```
+
+- `console=ttyS0,115200n8` : Active le port série à 115200 bauds
+- `console=tty1` : Garde aussi la console VGA standard
+
+### Architecture
+
+```
+ISO
+├── Kernel avec params série
+├── initrd
+├── NixOS base
+│   ├── Getty sur ttyS0 (autologin)
+│   ├── Getty sur tty1
+│   └── Getty sur tty2
+├── X11 (xterm + twm)
+└── Outils (vim, git, etc.)
+```
+
+## 🤝 Contribution
+
+Des idées pour améliorer cette ISO ? Ouvre une issue ou une PR !

--- a/iso/flake.nix
+++ b/iso/flake.nix
@@ -112,7 +112,6 @@
           services.openssh = {
             enable = true;
             settings = {
-              PermitRootLogin = "no";
               PasswordAuthentication = true;  # Activé pour l'ISO (désactiver en prod)
             };
           };

--- a/iso/flake.nix
+++ b/iso/flake.nix
@@ -14,7 +14,7 @@
         "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
 
         # Configuration personnalisée
-        ({ pkgs, ... }: {
+        ({ pkgs, lib, ... }: {
           # 🧠 Nom de l'hôte ISO
           networking.hostName = "nixos-iso-ttyS0";
 
@@ -132,9 +132,9 @@
 
           # 🎯 ISO metadata
           isoImage = {
-            isoName = "nixos-minimal-ttyS0.iso";
-            volumeID = "NIXOS_TTYS0";
-            appendToMenuLabel = " (avec support TTY série)";
+            isoName = lib.mkForce "nixos-minimal-ttyS0.iso";
+            volumeID = lib.mkForce "NIXOS_TTYS0";
+            appendToMenuLabel = lib.mkForce " (avec support TTY série)";
           };
         })
       ];

--- a/iso/flake.nix
+++ b/iso/flake.nix
@@ -105,8 +105,7 @@
           # 🔓 Permet sudo sans mot de passe pour l'utilisateur nixos
           security.sudo.wheelNeedsPassword = false;
 
-          # 🌐 Active le réseau DHCP automatiquement
-          networking.useDHCP = true;
+          # 🌐 Active NetworkManager (gère automatiquement le DHCP)
           networking.networkmanager.enable = true;
 
           # 🔧 SSH activé avec mot de passe temporaire (pratique pour debug)

--- a/iso/flake.nix
+++ b/iso/flake.nix
@@ -1,0 +1,143 @@
+{
+  description = "ISO NixOS minimale avec support TTY série (ttyS0) pour Proxmox/NoVNC";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  };
+
+  outputs = { self, nixpkgs }: {
+    nixosConfigurations.iso-minimal-ttyS0 = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+
+      modules = [
+        # Base ISO minimal officielle de NixOS
+        "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
+
+        # Configuration personnalisée
+        ({ pkgs, ... }: {
+          # 🧠 Nom de l'hôte ISO
+          networking.hostName = "nixos-iso-ttyS0";
+
+          # 🖥️ Configuration du boot pour console série
+          # console=ttyS0,115200n8 : active la console série (parfait pour Proxmox/NoVNC)
+          # console=tty1 : garde aussi la console graphique standard
+          boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty1" ];
+
+          # 🔌 Active plusieurs TTYs (tty1, tty2 et ttyS0 série)
+          services.getty = {
+            autologinUser = "nixos";  # Connexion automatique
+            helpLine = ''
+
+              Bienvenue sur l'ISO NixOS minimale avec support TTY série !
+
+              Cette ISO est configurée pour Proxmox/NoVNC avec :
+              - Console série sur ttyS0 (115200 baud)
+              - Autologin en tant que "nixos"
+              - Environnement X11 minimal avec xterm
+
+              Pour démarrer l'interface graphique : startx
+            '';
+          };
+
+          # 💻 Environnement X11 minimal avec xterm
+          services.xserver = {
+            enable = true;
+            # Désactive le display manager par défaut (on utilisera startx)
+            displayManager.startx.enable = true;
+          };
+
+          # 📦 Packages essentiels pour l'ISO
+          environment.systemPackages = with pkgs; [
+            # Interface graphique minimale
+            xterm
+            xorg.xinit
+            twm  # Tiny Window Manager (très léger)
+
+            # Outils de base
+            vim
+            git
+            curl
+            wget
+            htop
+            tree
+
+            # Outils réseau
+            inetutils
+            nmap
+
+            # Outils de diagnostic
+            pciutils
+            usbutils
+          ];
+
+          # 🐚 Configuration de ZSH comme shell par défaut
+          programs.zsh = {
+            enable = true;
+            enableCompletion = true;
+            autosuggestions.enable = true;
+            syntaxHighlighting.enable = true;
+          };
+
+          # ✨ Starship prompt moderne
+          programs.starship = {
+            enable = true;
+            settings = {
+              add_newline = false;
+              character = {
+                success_symbol = "[➜](bold green)";
+                error_symbol = "[➜](bold red)";
+              };
+              directory = {
+                truncation_length = 3;
+                truncate_to_repo = true;
+              };
+            };
+          };
+
+          # 👤 Configuration de l'utilisateur nixos (user par défaut de l'ISO)
+          users.users.nixos = {
+            isNormalUser = true;
+            extraGroups = [ "wheel" "networkmanager" ];
+            shell = pkgs.zsh;
+            initialPassword = "nixos";  # Mot de passe par défaut
+          };
+
+          # 🔓 Permet sudo sans mot de passe pour l'utilisateur nixos
+          security.sudo.wheelNeedsPassword = false;
+
+          # 🌐 Active le réseau DHCP automatiquement
+          networking.useDHCP = true;
+          networking.networkmanager.enable = true;
+
+          # 🔧 SSH activé avec mot de passe temporaire (pratique pour debug)
+          services.openssh = {
+            enable = true;
+            settings = {
+              PermitRootLogin = "no";
+              PasswordAuthentication = true;  # Activé pour l'ISO (désactiver en prod)
+            };
+          };
+
+          # 📝 Message de bienvenue dans le shell
+          programs.zsh.interactiveShellInit = ''
+            echo ""
+            echo "🚀 ISO NixOS minimale avec TTY série (ttyS0)"
+            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo ""
+            echo "  Pour démarrer X11 : startx"
+            echo "  User : nixos / Pass : nixos"
+            echo "  SSH activé sur port 22"
+            echo ""
+          '';
+
+          # 🎯 ISO metadata
+          isoImage = {
+            isoName = "nixos-minimal-ttyS0.iso";
+            volumeID = "NIXOS_TTYS0";
+            appendToMenuLabel = " (avec support TTY série)";
+          };
+        })
+      ];
+    };
+  };
+}

--- a/iso/flake.nix
+++ b/iso/flake.nix
@@ -106,6 +106,7 @@
           security.sudo.wheelNeedsPassword = false;
 
           # 🌐 Active NetworkManager (gère automatiquement le DHCP)
+          networking.wireless.enable = false;  # Désactive wpa_supplicant (conflit avec NetworkManager)
           networking.networkmanager.enable = true;
 
           # 🔧 SSH activé avec mot de passe temporaire (pratique pour debug)


### PR DESCRIPTION
Mise en place d'une configuration complète pour générer des ISO NixOS personnalisées optimisées pour Proxmox/NoVNC.

Nouveaux fichiers :
- iso/flake.nix : Configuration du builder ISO avec :
  * Console série (ttyS0) activée automatiquement
  * Autologin utilisateur nixos
  * Environnement X11 minimal (xterm + twm)
  * ZSH + Starship comme shell par défaut
  * SSH et réseau DHCP préconfigurés

- docs/ISO-BUILDER.md : Guide complet avec :
  * Instructions détaillées pour builder depuis une VM
  * Explication du problème TTY série sous Proxmox
  * Guide d'utilisation et personnalisation
  * Section dépannage

- iso/README.md : Documentation rapide du dossier iso/
- iso/.gitignore : Ignore les artifacts de build

Modifications :
- README.md : Ajout section ISO personnalisée et mise à jour de la structure du repository

Cette ISO résout le problème de terminal "muet" dans NoVNC en activant la console série dès le boot avec console=ttyS0,115200n8.