### PR TITLE
Deploy NixOS with n8n automation setup

### DIFF
--- a/scripts/install-nixos.sh
+++ b/scripts/install-nixos.sh
@@ -416,6 +416,9 @@ if [[ "${SKIP_SECRET_GENERATION:-false}" != "true" ]]; then
     info "Vous allez définir le mot de passe SSH pour cet host"
     echo ""
 
+    # Définir le chemin du fichier de secrets (doit correspondre à celui dans generate_secrets)
+    SECRETS_FILE="/tmp/secrets-${HOST}.yaml"
+
     # Installer les outils nécessaires temporairement
     nix-shell -p sops age openssl mkpasswd jq --run "$(declare -f generate_secrets error info warning step prompt); generate_secrets ${HOST}"
 


### PR DESCRIPTION
The SECRETS_FILE variable was exported inside a nix-shell subprocess, but this export didn't propagate back to the parent shell. This caused the script to fail with "unbound variable" error when trying to use SECRETS_FILE after the nix-shell command completed.

Fixed by defining SECRETS_FILE in the parent shell before calling nix-shell, using the same predictable path that generate_secrets creates.