### PR TITLE
Fix NixOS installation script variable error

### DIFF
--- a/scripts/install-nixos.sh
+++ b/scripts/install-nixos.sh
@@ -432,7 +432,8 @@ if [[ "${SKIP_SECRET_GENERATION:-false}" != "true" ]]; then
             cp /var/lib/sops-nix/key.txt /mnt/var/lib/sops-nix/key.txt
             chmod 600 /mnt/var/lib/sops-nix/key.txt
 
-            SOPS_AGE_KEY_FILE=/var/lib/sops-nix/key.txt sops encrypt "$SECRETS_FILE" > "$SECRETS_PATH"
+            # Utiliser nix-shell pour avoir accès à sops
+            nix-shell -p sops age --run "SOPS_AGE_KEY_FILE=/var/lib/sops-nix/key.txt sops encrypt '$SECRETS_FILE' > '$SECRETS_PATH'"
 
             # Vérifier que c'est bien chiffré
             if grep -q "sops:" "$SECRETS_PATH"; then


### PR DESCRIPTION
The sops encrypt command was being called outside of the nix-shell context, causing a "command not found" error. Wrapped the sops encrypt call in a nix-shell to ensure sops is available.