### PR TITLE
Add macOS compatibility to manage-secrets.sh

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,10 +29,13 @@ Script **indépendant** pour gérer les secrets, à utiliser **après l'installa
 
 ```bash
 # Depuis la racine du repo nix-config
-sudo ./scripts/manage-secrets.sh [magnolia|mimosa|whitelily]
+./scripts/manage-secrets.sh [magnolia|mimosa|whitelily]
 
 # Ou sans argument pour un menu interactif
-sudo ./scripts/manage-secrets.sh
+./scripts/manage-secrets.sh
+
+# Note: Sur NixOS, utilisez sudo si nécessaire
+# Sur macOS, pas besoin de sudo
 ```
 
 ### ✨ Ce qu'il fait
@@ -120,45 +123,74 @@ hosts/
 
 **Aucune manipulation manuelle nécessaire !**
 
-### 📝 Workflow complet
+### 📝 Workflow recommandé : Secrets depuis votre Mac ⭐
+
+**Le meilleur workflow** : créez les secrets depuis votre machine de dev, puis installez !
 
 ```bash
 # ========================================
-# Partie 1 : Installation (install-nixos.sh)
+# Partie 1 : Création des secrets (depuis votre Mac)
+# ========================================
+
+# Sur votre Mac
+cd ~/nix-config
+./scripts/manage-secrets.sh whitelily
+
+# Commit et push
+git add secrets/whitelily.yaml
+git commit -m "🔒 Add secrets for whitelily"
+git push
+
+# ========================================
+# Partie 2 : Installation (dans la VM)
 # ========================================
 
 # 1. Créer une VM dans Proxmox
 #    - Boot sur ISO NixOS 24.11
 #    - 2 CPU, 4GB RAM, 32GB disque (whitelily)
-#    - 2 CPU, 2GB RAM, 20GB disque (magnolia/mimosa)
 
 # 2. Dans la console VM
 curl -L https://raw.githubusercontent.com/JeremieAlcaraz/nix-config/main/scripts/install-nixos.sh -o install.sh
 chmod +x install.sh
-sudo ./install.sh whitelily  # Ou magnolia/mimosa
+sudo ./install.sh whitelily
 
-# 3. Attendre la fin de l'installation (5-10 min)
-#    Le script s'arrête automatiquement
+# → Le script détecte les secrets dans le repo
+# → Installation complète avec les secrets
 
-# 4. Sur Proxmox : détacher l'ISO et redémarrer
+# 3. Détacher l'ISO et redémarrer
 qm set <VMID> --ide2 none
 qm start <VMID>
 
-# ========================================
-# Partie 2 : Création des secrets (manage-secrets.sh)
-# ========================================
+# 4. Se connecter
+ssh jeremie@<IP>
+```
 
-# 5. Se connecter en root
+**Temps total : ~10-15 minutes** ⏱️
+
+**Avantages** :
+- ✅ Plus rapide (pas de création de secrets après l'installation)
+- ✅ Plus sûr (secrets commités avant, versionnés dans git)
+- ✅ Environnement familier (votre Mac)
+- ✅ Réutilisable (secrets déjà là pour réinstaller)
+
+### 📝 Workflow alternatif : Secrets après installation
+
+Si vous préférez créer les secrets après l'installation :
+
+```bash
+# 1-3. Installation (comme ci-dessus)
+
+# 4. Se connecter en root
 ssh root@<IP>
 
-# 6. Créer les secrets
+# 5. Créer les secrets
 cd /etc/nixos
 ./scripts/manage-secrets.sh whitelily
 
-# 7. Déployer la configuration avec les secrets
+# 6. Déployer la configuration avec les secrets
 nixos-rebuild switch --flake .#whitelily
 
-# 8. Se reconnecter avec l'utilisateur normal
+# 7. Se reconnecter avec l'utilisateur normal
 exit
 ssh jeremie@<IP>
 ```

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -14,19 +14,28 @@ Ce répertoire contient les secrets chiffrés avec sops pour les différents hô
 
 ### 🚀 Usage
 
+**Sur macOS (recommandé)** :
 ```bash
-# Créer ou régénérer les secrets pour un host
+# Depuis votre repo local
+cd ~/nix-config
+./scripts/manage-secrets.sh [magnolia|mimosa|whitelily]
+```
+
+**Sur NixOS (après installation)** :
+```bash
+# Depuis le système installé
 cd /etc/nixos
 sudo ./scripts/manage-secrets.sh [magnolia|mimosa|whitelily]
 ```
 
 ### ✨ Le script fait tout automatiquement
 
-1. ✅ Vérifie les outils nécessaires (sops, age, openssl, mkpasswd)
-2. ✅ Vérifie/configure la clé age
-3. ✅ Génère les secrets de manière interactive
-4. ✅ Sauvegarde les anciens secrets avant modification
-5. ✅ Chiffre automatiquement avec sops
+1. ✅ Détecte votre OS (macOS ou Linux) et s'adapte
+2. ✅ Vérifie les outils nécessaires (sops, age, openssl)
+3. ✅ Vérifie/configure la clé age
+4. ✅ Génère les secrets de manière interactive
+5. ✅ Sauvegarde les anciens secrets avant modification
+6. ✅ Chiffre automatiquement avec sops
 
 ### 📦 Après génération
 
@@ -50,6 +59,17 @@ git push
 - 🎯 **Interactif** : Le script vous guide étape par étape
 - 💾 **Backup** : Les anciens secrets sont automatiquement sauvegardés
 - ⚡ **Chiffrement** : Automatique et transparent avec sops
+- 🍎 **Compatible macOS** : Fonctionne sur votre Mac sans modification
+
+### 🛠️ Installation des outils (macOS)
+
+Si vous n'avez pas encore sops et age sur votre Mac :
+
+```bash
+brew install sops age
+```
+
+C'est tout ! Le script utilisera `openssl` (déjà installé sur macOS) pour les hash de mots de passe.
 
 ## Fichiers
 


### PR DESCRIPTION
Enable secret management from development machine (macOS) for better workflow and security.

Changes to manage-secrets.sh:
- Add detect_os() function to identify macOS vs Linux
- Add generate_password_hash() for cross-platform password hashing
  - macOS: use openssl passwd -6 (SHA-512)
  - Linux: use mkpasswd -m sha-512
- Update check_requirements() to skip mkpasswd check on macOS
- Update check_age_key() to use different paths per OS
  - macOS: $HOME/.config/sops/age/keys.txt
  - Linux: /var/lib/sops-nix/key.txt
- Remove sudo requirement on macOS
- Replace all mkpasswd calls with generate_password_hash()

Changes to documentation:
- scripts/README.md: Add macOS workflow as recommended
- scripts/README.md: Show secrets-first workflow (create on Mac, then install)
- secrets/README.md: Add macOS-specific usage instructions
- secrets/README.md: Add brew install instructions for macOS

Benefits:
- Create secrets from familiar dev environment (Mac)
- Secrets committed before installation (better security)
- Faster workflow (no post-install secret creation needed)
- Cross-platform script (works on macOS and Linux)