### PR TITLE
Fix sed compatibility for macOS

### DIFF
--- a/scripts/manage-secrets.sh
+++ b/scripts/manage-secrets.sh
@@ -65,6 +65,21 @@ generate_password_hash() {
     fi
 }
 
+# Fonction sed compatible multi-OS
+sed_inplace() {
+    local pattern="$1"
+    local file="$2"
+    local os=$(detect_os)
+
+    if [[ "$os" == "macos" ]]; then
+        # Sur macOS (BSD sed), -i nécessite un argument
+        sed -i '' "$pattern" "$file"
+    else
+        # Sur Linux (GNU sed)
+        sed -i "$pattern" "$file"
+    fi
+}
+
 # Vérifications initiales
 check_requirements() {
     local missing=()
@@ -306,7 +321,7 @@ EOF
         update_domain="${update_domain:-oui}"
 
         if [[ "$update_domain" == "oui" ]]; then
-            sed -i "s|domain = \".*\";|domain = \"${DOMAIN}\";|" "hosts/whitelily/n8n.nix"
+            sed_inplace "s|domain = \".*\";|domain = \"${DOMAIN}\";|" "hosts/whitelily/n8n.nix"
             info "Domaine mis à jour dans n8n.nix : ${DOMAIN}"
         fi
     fi


### PR DESCRIPTION
BSD sed (macOS) requires an empty string argument for -i flag, while GNU sed (Linux) does not.

Add sed_inplace() helper function to handle cross-platform sed usage.

Changes:
- Add sed_inplace() function that detects OS and uses correct syntax
- Replace direct sed -i call with sed_inplace() wrapper
- macOS: sed -i '' (requires empty backup extension)
- Linux: sed -i (no backup extension needed)

Fixes: sed error when updating domain in whitelily n8n.nix on macOS