### PR TITLE
🔧 Force sops-nix to use age key file only for whitelily

### DIFF
--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -77,6 +77,7 @@
     defaultSopsFile = ../../secrets/whitelily.yaml;
     age = {
       keyFile = "/var/lib/sops-nix/key.txt";
+      sshKeyPaths = []; # Désactiver l'utilisation des clés SSH
     };
     secrets = {
       # Hash du mot de passe de l'utilisateur jeremie


### PR DESCRIPTION
- Disable SSH key usage with sshKeyPaths = []
- Ensure only /var/lib/sops-nix/key.txt is used for decryption
- Fixes cloudflared/token secret not being deployed

This resolves the issue where sops-nix was using SSH host keys (age183l8...) instead of the configured age key (age1nt3ly...).