### PR TITLE
🔧 Use SSH ed25519 key for sops-nix on whitelily

### DIFF
--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -76,8 +76,8 @@
   sops = {
     defaultSopsFile = ../../secrets/whitelily.yaml;
     age = {
-      keyFile = "/var/lib/sops-nix/key.txt";
-      sshKeyPaths = []; # Désactiver l'utilisation des clés SSH
+      # Utiliser la clé SSH ed25519 de l'hôte (convertie automatiquement en age)
+      sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
     };
     secrets = {
       # Hash du mot de passe de l'utilisateur jeremie


### PR DESCRIPTION
- Switch from separate age keyFile to SSH host key
- SSH keys are automatically available during boot/rebuild
- Fixes issue where /var/lib/sops-nix/key.txt was not accessible

This requires rechiffering secrets/whitelily.yaml with the age key derived from /etc/ssh/ssh_host_ed25519_key (age183l8gur3uaeqz7aa722nm3jcme0svy2rucprjlgjmlugs3gtggyqce00u0)