### PR TITLE
🔧 Revert to shared age key for whitelily

### DIFF
--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -76,8 +76,8 @@
   sops = {
     defaultSopsFile = ../../secrets/whitelily.yaml;
     age = {
-      # Utiliser la clé SSH ed25519 de l'hôte (convertie automatiquement en age)
-      sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+      # Utiliser la clé age partagée (copiée depuis le Mac)
+      keyFile = "/var/lib/sops-nix/key.txt";
     };
     secrets = {
       # Hash du mot de passe de l'utilisateur jeremie


### PR DESCRIPTION
- Use shared age key from /var/lib/sops-nix/key.txt
- This key is shared across all VMs (mimosa, magnolia, whitelily)
- Removes SSH key dependency for better portability

The key file must exist on the VM at /var/lib/sops-nix/key.txt with the shared age private key.