### PR TITLE
🔧 Force sops-nix to use shared age key only on whitelily

### DIFF
--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -76,8 +76,10 @@
   sops = {
     defaultSopsFile = ../../secrets/whitelily.yaml;
     age = {
-      # Utiliser la clé age partagée (copiée depuis le Mac)
+      # Utiliser UNIQUEMENT la clé age partagée (copiée depuis le Mac)
       keyFile = "/var/lib/sops-nix/key.txt";
+      # Désactiver les clés SSH pour forcer l'utilisation de keyFile
+      sshKeyPaths = [];
     };
     secrets = {
       # Hash du mot de passe de l'utilisateur jeremie


### PR DESCRIPTION
- Add sshKeyPaths = [] to disable SSH key usage
- This ensures only /var/lib/sops-nix/key.txt is used
- The shared age key (age1nt3ly...) is used across all VMs

Without sshKeyPaths = [], sops-nix defaults to using SSH host keys even when keyFile is specified, which prevents the shared age key from being used.