### PR TITLE
🔧 Fix n8n.env persistence across NixOS rebuilds

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -85,6 +85,8 @@ in {
   systemd.services."n8n-envfile" = {
     description = "Render n8n env file from sops secrets";
     wantedBy = [ "multi-user.target" ];
+    after = [ "sops-nix.service" ];
+    requires = [ "sops-nix.service" ];
     before = [ "podman-n8n.service" ];
     serviceConfig = {
       Type = "oneshot";
@@ -157,6 +159,12 @@ EOF
         "--health-retries=3"
       ];
     };
+  };
+
+  # Ajouter les dépendances au service généré par oci-containers
+  systemd.services."podman-n8n" = {
+    after = [ "n8n-envfile.service" "postgresql.service" ];
+    requires = [ "n8n-envfile.service" "postgresql.service" ];
   };
 
   # Répertoires de données et de backup


### PR DESCRIPTION
- Add sops-nix.service dependency to n8n-envfile service
- Ensure n8n-envfile runs AFTER sops-nix finishes cleaning /run/secrets
- Add explicit dependencies for podman-n8n service
- Guarantees proper startup order: sops → n8n-envfile → postgresql → podman-n8n

This fixes the "removing secret: n8n.env" issue where sops-nix would delete the manually created env file during system activation.