### PR TITLE
🔧 Fix service dependency name: sops-nix → sops-install-secrets

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -85,8 +85,8 @@ in {
   systemd.services."n8n-envfile" = {
     description = "Render n8n env file from sops secrets";
     wantedBy = [ "multi-user.target" ];
-    after = [ "sops-nix.service" ];
-    requires = [ "sops-nix.service" ];
+    after = [ "sops-install-secrets.service" ];
+    requires = [ "sops-install-secrets.service" ];
     before = [ "podman-n8n.service" ];
     serviceConfig = {
       Type = "oneshot";


### PR DESCRIPTION
The actual systemd service is called "sops-install-secrets.service" not "sops-nix.service". This was causing startup failures: "Failed to start n8n-envfile.service: Unit sops-nix.service not found."