### PR TITLE
🔧 Fix /var/lib/n8n permissions for n8n container

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -168,7 +168,8 @@ EOF
   # Répertoires de données et de backup
   systemd.tmpfiles.rules = [
     # Données n8n, Caddy et Cloudflared
-    "d /var/lib/n8n 0750 root root -"
+    # n8n tourne en tant qu'utilisateur node (UID 1000) dans le conteneur
+    "d /var/lib/n8n 0750 1000 1000 -"
     "d /run/n8n 0700 root root -"  # Pour le fichier n8n.env
     "d /var/log/caddy 0750 caddy caddy -"
     "d /var/lib/cloudflared 0750 cloudflared cloudflared -"


### PR DESCRIPTION
- Change ownership from root:root to 1000:1000
- n8n runs as user 'node' (UID 1000) inside the container
- Fixes EACCES permission denied errors on /home/node/.n8n/config

This allows the n8n container to write its configuration and data files.