### PR TITLE
🏥 Add healthcheck grace period to prevent false failures during startup

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -150,11 +150,12 @@ EOF
         # Fichier d'environnement avec les secrets (contient les variables DB_*)
         # Déplacé de /run/secrets vers /run/n8n pour éviter que sops-nix le supprime
         "--env-file=/run/n8n/n8n.env"
-        # Healthcheck
+        # Healthcheck avec période de grâce au démarrage
         "--health-cmd=wget --no-verbose --tries=1 --spider http://localhost:5678/healthz || exit 1"
         "--health-interval=30s"
         "--health-timeout=10s"
         "--health-retries=3"
+        "--health-start-period=60s"  # 60s de grâce au démarrage avant que les échecs comptent
       ];
     };
   };


### PR DESCRIPTION
Add --health-start-period=60s to give n8n container time to fully initialize before healthcheck failures are counted.

This prevents the scary error message during nixos-rebuild that appears when the healthcheck runs too early while n8n is still starting up (connecting to DB, initializing workflows, etc.).

The container now has 60 seconds of grace period where healthcheck failures don't count, eliminating false positives during deployment.