### PR TITLE
🧹 Remove Podman healthcheck - use systemd timer instead

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -150,12 +150,8 @@ EOF
         # Fichier d'environnement avec les secrets (contient les variables DB_*)
         # Déplacé de /run/secrets vers /run/n8n pour éviter que sops-nix le supprime
         "--env-file=/run/n8n/n8n.env"
-        # Healthcheck avec période de grâce au démarrage
-        "--health-cmd=wget --no-verbose --tries=1 --spider http://localhost:5678/healthz || exit 1"
-        "--health-interval=30s"
-        "--health-timeout=10s"
-        "--health-retries=3"
-        "--health-start-period=60s"  # 60s de grâce au démarrage avant que les échecs comptent
+        # Note: Pas de healthcheck Podman, on utilise le timer systemd dédié (n8n-healthcheck.timer)
+        # qui vérifie toutes les 5 minutes sans polluer les logs de nixos-rebuild
       ];
     };
   };


### PR DESCRIPTION
Remove redundant Podman healthcheck that was polluting nixos-rebuild logs with false failure messages during container startup.

The existing n8n-healthcheck.timer (runs every 5 minutes) is sufficient for monitoring and provides cleaner logs without the noise of healthcheck failures during normal startup.

Benefits:
- No more scary healthcheck errors during nixos-rebuild
- Simpler monitoring (single source of truth)
- Easier to debug (systemd journal instead of podman events)
- Less resource usage (5min interval vs 30s)