### PR TITLE
🐛 Fix: Ajout de N8N_PROXY_HOPS pour trust proxy

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -147,6 +147,10 @@ EOF
         N8N_TEMPLATES_ENABLED = "true";
         N8N_PUBLIC_API_DISABLED = "false";
 
+        # Configuration reverse proxy (Cloudflare Tunnel → Caddy → n8n)
+        # Active trust proxy pour les headers X-Forwarded-*
+        N8N_PROXY_HOPS = "1";
+
         # Configuration des permissions et sécurité
         N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS = "true";
         N8N_RUNNERS_ENABLED = "true";


### PR DESCRIPTION
Corrige l'erreur :
ValidationError: The 'X-Forwarded-For' header is set but the Express 'trust proxy' setting is false (default).

Caddy envoie les headers X-Forwarded-* à n8n mais n8n ne leur faisait pas confiance par défaut. L'ajout de N8N_PROXY_HOPS=1 indique à n8n qu'il est derrière 1 reverse proxy (Caddy).

Architecture : Cloudflare Tunnel → Caddy → n8n