### PR TITLE
Troubleshoot domain name change issues

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -200,8 +200,8 @@ EOF
 
     # Configuration globale
     globalConfig = ''
-      # Désactiver la télémétrie
-      admin off
+      # API admin accessible uniquement en local (nécessaire pour les reloads)
+      admin localhost:2019
     '';
 
     virtualHosts."${domain}" = {


### PR DESCRIPTION
Remplace `admin off` par `admin localhost:2019` dans la configuration Caddy.

Le problème : avec `admin off`, Caddy désactive complètement son API d'administration, empêchant nixos-rebuild de recharger la configuration lors d'un changement de domaine.

La solution : `admin localhost:2019` permet les reloads tout en gardant l'API sécurisée (accessible uniquement en local).