### PR TITLE
French Language Question Incomplete

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -2,7 +2,7 @@
 
 let
   # Configuration du domaine n8n
-  domain = "n8nv2.jeremiealcaraz.com";  # ← À adapter selon ton domaine
+  domain = "n8n.jeremiealcaraz.com";  # ← À adapter selon ton domaine
 
   # Script pour lancer cloudflared avec le token depuis sops
   cloudflaredTunnelScript = pkgs.writeShellScript "cloudflared-tunnel" ''
@@ -107,17 +107,18 @@ in {
 
       # Créer le fichier .env avec toutes les variables nécessaires
       # On le met dans /run/n8n/ pour éviter que sops-nix le supprime
+      # Les valeurs sont entre guillemets pour gérer les caractères spéciaux
       cat > /run/n8n/n8n.env <<EOF
-N8N_ENCRYPTION_KEY=$ENCRYPTION_KEY
+N8N_ENCRYPTION_KEY="$ENCRYPTION_KEY"
 N8N_BASIC_AUTH_ACTIVE=true
-N8N_BASIC_AUTH_USER=$BASIC_USER
-N8N_BASIC_AUTH_PASSWORD=$BASIC_PASS
+N8N_BASIC_AUTH_USER="$BASIC_USER"
+N8N_BASIC_AUTH_PASSWORD="$BASIC_PASS"
 DB_TYPE=postgresdb
 DB_POSTGRESDB_HOST=127.0.0.1
 DB_POSTGRESDB_PORT=5432
 DB_POSTGRESDB_DATABASE=n8n
 DB_POSTGRESDB_USER=n8n
-DB_POSTGRESDB_PASSWORD=$DB_PASSWORD
+DB_POSTGRESDB_PASSWORD="$DB_PASSWORD"
 DB_POSTGRESDB_CONNECTION_TIMEOUT=30000
 EOF
 

--- a/scripts/manage-secrets.sh
+++ b/scripts/manage-secrets.sh
@@ -519,7 +519,8 @@ generate_whitelily_secrets() {
 
         if [[ "$create_new_db_password" == "oui" ]]; then
             info "Génération du mot de passe DB PostgreSQL..."
-            DB_PASSWORD=$(openssl rand -base64 32)
+            # Utiliser hex au lieu de base64 pour éviter les caractères spéciaux (+, /, =)
+            DB_PASSWORD=$(openssl rand -hex 32)
             echo "Nouveau mot de passe DB: ${DB_PASSWORD}"
         else
             echo ""


### PR DESCRIPTION
- Change génération du mot de passe DB de base64 vers hex pour éviter les caractères spéciaux (+, /, =)
- Ajoute des guillemets autour des valeurs dans le fichier .env n8n pour gérer correctement les caractères spéciaux
- Corrige le domaine n8n (n8nv2 → n8n.jeremiealcaraz.com)

Le problème était que le mot de passe PostgreSQL en base64 se terminait par '=' (padding) ce qui causait des problèmes de parsing dans le fichier .env de n8n.

Erreur résolue: "SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string"