### PR TITLE
🐛 Fix: Correction de l'accès aux secrets sops pour n8n

### DIFF
--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -90,7 +90,7 @@
       "n8n/encryption_key" = { owner = "root"; group = "root"; mode = "0400"; };
       "n8n/basic_user" = { owner = "root"; group = "root"; mode = "0400"; };
       "n8n/basic_pass" = { owner = "root"; group = "root"; mode = "0400"; };
-      "n8n/db_password" = { owner = "postgres"; group = "postgres"; mode = "0400"; };
+      "n8n/db_password" = { owner = "root"; group = "root"; mode = "0400"; };
       # Cloudflare Tunnel token (simplifié)
       "cloudflared/token" = { owner = "cloudflared"; group = "cloudflared"; mode = "0400"; };
       # GitHub token pour auto-update workflow

--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -90,6 +90,8 @@ in {
   systemd.services."n8n-envfile" = {
     description = "Render n8n env file from sops secrets";
     wantedBy = [ "multi-user.target" ];
+    after = [ "sops-install-secrets.service" ];
+    wants = [ "sops-install-secrets.service" ];
     before = [ "podman-n8n.service" ];
     serviceConfig = {
       Type = "oneshot";


### PR DESCRIPTION
Problème: Les variables d'environnement dans /run/n8n/n8n.env étaient vides car le service n8n-envfile s'exécutait avant que les secrets sops ne soient disponibles.

Corrections:
- Ajout de la dépendance after/wants sur sops-install-secrets.service dans n8n-envfile
- Changement du owner de n8n/db_password de postgres à root (le service n8n-envfile tourne en root)

Cela garantit que:
1. Les secrets sont déchiffrés AVANT que n8n-envfile ne les lise
2. Le service n8n-envfile a les permissions pour lire tous les secrets nécessaires

Les secrets sont maintenant correctement propagés dans le fichier .env de n8n.