### PR TITLE
Debug Cloudflared tunnel and Caddy service failures

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -8,9 +8,10 @@ let
   cloudflaredTunnelScript = pkgs.writeShellScript "cloudflared-tunnel" ''
     set -euo pipefail
 
-    # Lire le token, nettoyer les espaces, et extraire la valeur après "token:"
-    # Le secret sops contient "token: eyJxxxx" mais cloudflared attend juste "eyJxxxx"
-    TOKEN="$(${pkgs.coreutils}/bin/cat ${config.sops.secrets."cloudflared/token".path} | ${pkgs.findutils}/bin/xargs | ${pkgs.gawk}/bin/awk '{print $2}')"
+    # Lire le token et extraire la valeur
+    # Le secret sops peut contenir soit "token: eyJxxxx" soit juste "eyJxxxx"
+    # On gère les deux cas comme pour les secrets n8n
+    TOKEN="$(${pkgs.coreutils}/bin/cat ${config.sops.secrets."cloudflared/token".path} | ${pkgs.findutils}/bin/xargs | ${pkgs.gawk}/bin/awk '{if (NF==2) print $2; else print $0}')"
 
     exec ${pkgs.cloudflared}/bin/cloudflared tunnel run --token "$TOKEN"
   '';


### PR DESCRIPTION
Le service cloudflared-tunnel crashait (exit code 255) car le script d'extraction du token utilisait 'awk {print $2}' qui ne fonctionne que si le secret contient "token: VALUE". Si le secret contient uniquement la valeur du token, cette commande retourne une chaîne vide, causant le crash de cloudflared.

Changements:
- Mise à jour de l'extraction du token pour utiliser le même pattern que les secrets n8n
- Utilisation de '{if (NF==2) print $2; else print $0}' pour gérer les deux cas:
  * Format "token: VALUE" → extrait VALUE
  * Format "VALUE" → extrait VALUE directement

Le service devrait maintenant démarrer correctement après un rebuild.