### PR TITLE
🔧 Fix: Amélioration du script postStart PostgreSQL pour n8n

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -62,17 +62,48 @@ in {
 
   # Initialisation du mot de passe PostgreSQL pour l'utilisateur n8n
   systemd.services.postgresql.postStart = lib.mkAfter ''
-    # Nettoyer le mot de passe de tous les caractères parasites (guillemets, newlines, espaces)
-    DB_PASS=$(${pkgs.coreutils}/bin/cat /run/secrets/n8n/db_password | ${pkgs.coreutils}/bin/tr -d '\n"' | ${pkgs.findutils}/bin/xargs | ${pkgs.gawk}/bin/awk '{if (NF==2) print $2; else print $0}')
+    set -euo pipefail
 
+    echo "[n8n-setup] Début de la configuration du mot de passe PostgreSQL"
+
+    # Vérifier que le secret existe
+    if [ ! -f /run/secrets/n8n/db_password ]; then
+      echo "[n8n-setup] ERREUR: Le secret /run/secrets/n8n/db_password n'existe pas !"
+      exit 1
+    fi
+
+    # Nettoyer le mot de passe (enlever newlines, guillemets, espaces)
+    DB_PASS=$(${pkgs.coreutils}/bin/cat /run/secrets/n8n/db_password | ${pkgs.coreutils}/bin/tr -d '\n"' | ${pkgs.findutils}/bin/xargs)
+
+    echo "[n8n-setup] Mot de passe lu et nettoyé (longueur: ''${#DB_PASS} caractères)"
+
+    # Attendre que PostgreSQL soit vraiment prêt
+    echo "[n8n-setup] Attente que PostgreSQL soit prêt..."
+    for i in {1..30}; do
+      if $PSQL -c '\q' 2>/dev/null; then
+        echo "[n8n-setup] PostgreSQL est prêt !"
+        break
+      fi
+      sleep 1
+    done
+
+    # Mettre à jour le mot de passe (syntaxe SQL simple, pas de DO $$)
+    echo "[n8n-setup] Configuration du mot de passe pour l'utilisateur n8n"
     $PSQL -tA <<EOF
-      DO \$\$
-      DECLARE password TEXT;
-      BEGIN
-        password := '$DB_PASS';
-        EXECUTE format('ALTER USER n8n WITH PASSWORD %L', password);
-      END \$\$;
-    EOF
+ALTER USER n8n WITH PASSWORD '$DB_PASS';
+GRANT ALL PRIVILEGES ON DATABASE n8n TO n8n;
+EOF
+
+    # Configurer les permissions sur le schéma public
+    echo "[n8n-setup] Configuration des permissions sur le schéma public"
+    $PSQL -d n8n -tA <<EOF
+ALTER SCHEMA public OWNER TO n8n;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO n8n;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO n8n;
+GRANT ALL PRIVILEGES ON SCHEMA public TO n8n;
+EOF
+
+    echo "[n8n-setup] Configuration PostgreSQL terminée avec succès !"
   '';
 
   ########################################


### PR DESCRIPTION
## Problème identifié
Le script postgresql.postStart ne s'exécutait pas correctement, causant:
- L'utilisateur n8n n'avait AUCUN mot de passe assigné dans PostgreSQL
- Erreur: "User 'n8n' has no password assigned"
- Le script échouait silencieusement sans logs

## Corrections appliquées
1. ✅ Ajout de logs détaillés avec préfixe [n8n-setup]
2. ✅ Vérification de l'existence du secret avant lecture
3. ✅ Attente active que PostgreSQL soit prêt (boucle 30s)
4. ✅ Simplification SQL: Suppression du DO $$ complexe
5. ✅ Gestion d'erreurs: set -euo pipefail
6. ✅ Configuration complète des permissions sur le schéma public

## Script avant
- Utilisait DO $$ avec échappement complexe qui pouvait échouer
- Pas de logs, impossible de débugger
- Pas de vérification que PostgreSQL est prêt

## Script après
- SQL simple: ALTER USER n8n WITH PASSWORD '$DB_PASS'
- Logs à chaque étape pour debugging facile
- Attente explicite que PostgreSQL soit prêt
- Gestion d'erreurs stricte (exit si problème)

À chaque rebuild, le mot de passe sera maintenant automatiquement synchronisé.