### PR TITLE
Fix missing n8n backup configuration value

### DIFF
--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -117,13 +117,10 @@
     # Chemin dans Google Drive où stocker les backups
     # Tu dois avoir créé ce dossier dans GDrive : backups/n8n
     gdrivePath = "backups/n8n";
-    
-    # ID du dossier Google Drive (pour générer le lien cliquable dans Notion)
-    # ⚠️ REMPLACE "1aB2cD3eF4gH5iJ6kL7mN8oP9qR0sT" PAR TON VRAI ID
-    # Tu l'as récupéré dans la Partie 1 avec :
-    # rclone lsf gdrive:backups/n8n --dirs-only --format "pi" --absolute
-    # gdriveFolderId = "1aB2cD3eF4gH5iJ6kL7mN8oP9qR0sT";
-    
+
+    # Note: L'ID du dossier Google Drive est lu depuis les secrets sops
+    # (google_drive/folder_id) et n'a plus besoin d'être configuré ici
+
     # Calendrier systemd (format OnCalendar) pour l'exécution du backup
     # "*-*-* 00:00:00" = tous les jours à minuit
     # Tu peux changer pour :

--- a/hosts/whitelily/n8n-backup.nix
+++ b/hosts/whitelily/n8n-backup.nix
@@ -33,6 +33,7 @@ let
     GMAIL_TO=$(cat ${config.sops.secrets."gmail/to".path})
     GMAIL_PASSWORD=$(cat ${config.sops.secrets."gmail/app_password".path})
     SLACK_WEBHOOK=$(cat ${config.sops.secrets."slack/webhook_url".path})
+    GDRIVE_FOLDER_ID=$(cat ${config.sops.secrets."google_drive/folder_id".path})
     
     # Variables du backup
     BACKUP_DATE=$(date +%Y%m%d_%H%M%S)
@@ -257,8 +258,8 @@ let
         else
             local duration=$(($(date +%s) - START_TIME))
             local archive_size=$(ls -lh "$BACKUP_DIR/$BACKUP_ARCHIVE" | awk '{print $5}')
-            local gdrive_url="https://drive.google.com/drive/folders/${cfg.gdriveFolderId}"
-            
+            local gdrive_url="https://drive.google.com/drive/folders/''${GDRIVE_FOLDER_ID}"
+
             log_to_notion "success" "''${gdrive_url}" "''${archive_size}" "''${duration}"
             send_slack_notification "success"
         fi
@@ -564,11 +565,11 @@ let
     # ÉTAPE 14 : Notifications et finalisation
     # ----------------------------------------------------------------
     log "[14/14] 📢 Envoi des notifications..."
-    
+
     END_TIME=$(date +%s)
     DURATION=$((END_TIME - START_TIME))
-    GDRIVE_URL="https://drive.google.com/drive/folders/${cfg.gdriveFolderId}"
-    
+    GDRIVE_URL="https://drive.google.com/drive/folders/''${GDRIVE_FOLDER_ID}"
+
     send_notifications "success"
     
     log ""
@@ -608,12 +609,7 @@ in {
       default = "backups/n8n";
       description = "Chemin dans Google Drive où stocker les backups";
     };
-    
-    gdriveFolderId = mkOption {
-      type = types.str;
-      description = "ID du dossier Google Drive (pour générer le lien)";
-    };
-    
+
     schedule = mkOption {
       type = types.str;
       default = "*-*-* 00:00:00";


### PR DESCRIPTION
The n8n-backup module was requiring a `gdriveFolderId` config option that wasn't set, causing the error:
  "The option `services.n8n-backup.gdriveFolderId' was accessed but has no value defined"

Changes:
- Read GDRIVE_FOLDER_ID directly from sops secret at runtime
- Remove gdriveFolderId as a required config option
- Update URL generation to use the secret value
- Clean up configuration.nix comments

The folder ID is now consistently read from the existing sops secret (google_drive/folder_id) across all uses in the backup script.