### PR TITLE
Improve n8n backup tar diagnostics

### DIFF
--- a/hosts/whitelily/n8n-backup.nix
+++ b/hosts/whitelily/n8n-backup.nix
@@ -384,10 +384,13 @@ let
         ${pkgs.systemd}/bin/systemctl start podman-n8n.service
         error_exit "Répertoire n8n introuvable: ''${N8N_DATA_PATH}"
     fi
-    
-    if ! ${pkgs.gnutar}/bin/tar czf n8n_data_real.tar.gz -C "$(${pkgs.coreutils}/bin/dirname "$N8N_DATA_PATH")" "$(${pkgs.coreutils}/bin/basename "$N8N_DATA_PATH")" 2>/dev/null; then
+
+    log "   N8N_DATA_PATH = ''${N8N_DATA_PATH}"
+
+    if ! ${pkgs.gnutar}/bin/tar czf n8n_data_real.tar.gz -C "$(${pkgs.coreutils}/bin/dirname "$N8N_DATA_PATH")" "$(${pkgs.coreutils}/bin/basename "$N8N_DATA_PATH")"; then
+        rc=$?
         ${pkgs.systemd}/bin/systemctl start podman-n8n.service
-        error_exit "Échec de l'archivage des fichiers n8n"
+        error_exit "Échec de l'archivage des fichiers n8n (tar exit code ''${rc})"
     fi
 
     DATA_SIZE=$(${pkgs.coreutils}/bin/ls -lh n8n_data_real.tar.gz | ${pkgs.gawk}/bin/awk '{print $5}')


### PR DESCRIPTION
## Summary
- log the detected n8n data path before creating the archive
- keep tar stderr visible and include its exit code in the failure message to simplify debugging

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1cec89f4832fa3d666d004dd2671)