### PR TITLE
Ensure n8n backup service has gzip

### DIFF
--- a/hosts/whitelily/n8n-backup.nix
+++ b/hosts/whitelily/n8n-backup.nix
@@ -715,7 +715,7 @@ EOF
       after = [ "network-online.target" "podman-n8n.service" "postgresql.service" "n8n-backup-rclone-config.service" ];
       wants = [ "network-online.target" ];
       requires = [ "n8n-backup-rclone-config.service" ];
-      
+
       serviceConfig = {
         Type = "oneshot";
         ExecStart = "${backupScript}";
@@ -724,6 +724,10 @@ EOF
         StandardError = "append:${cfg.logFile}";
         TimeoutStartSec = 1800; # 30 minutes max
       };
+
+      path = with pkgs; [
+        gzip
+      ];
     };
     
     # Timer systemd


### PR DESCRIPTION
## Summary
- add `gzip` to the `systemd.services."n8n-backup".path` so tar can invoke it when run by the service

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1e158bac832f8cdedcf1e5566954)