### PR TITLE
Move tailscale module to top-level modules

### DIFF
--- a/modules/tailscale.nix
+++ b/modules/tailscale.nix
@@ -130,8 +130,8 @@ in
   # sops-nix les déchiffre automatiquement au boot et les rend accessibles
   # sous /run/secrets/<nom-du-secret>
   sops.secrets = {
-    tailscale_oauth_client_id.sopsFile = ../../secrets/common.yaml;
-    tailscale_oauth_client_secret.sopsFile = ../../secrets/common.yaml;
-    tailscale_tailnet.sopsFile = ../../secrets/common.yaml;  # ← AJOUT
+    tailscale_oauth_client_id.sopsFile = ../secrets/common.yaml;
+    tailscale_oauth_client_secret.sopsFile = ../secrets/common.yaml;
+    tailscale_tailnet.sopsFile = ../secrets/common.yaml;  # ← AJOUT
   };
 })


### PR DESCRIPTION
## Summary
- move the tailscale module out of modules/common to modules/tailscale.nix
- adjust sops secret paths to reflect the new location

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f4c7973b4832fa17eb7676266e945)