### PR TITLE
Make mimosa webserver optional

### DIFF
--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -92,6 +92,8 @@
   # Ce fichier est importé uniquement dans la configuration "mimosa" complète (via flake.nix)
   # La configuration "mimosa-minimal" n'importe PAS ce fichier pour éviter
   # les téléchargements npm pendant l'installation initiale
+  # Activer/désactiver facilement le serveur web pour éviter les builds durant le boot
+  mimosa.webserver.enable = false; # Passer à true pour réactiver le déploiement web
 
   # Tailscale
   services.tailscale = {

--- a/hosts/mimosa/webserver.nix
+++ b/hosts/mimosa/webserver.nix
@@ -2,23 +2,30 @@
 # Ce fichier est importé uniquement dans la configuration "mimosa" complète
 # Pour éviter les erreurs, il n'est PAS importé dans "mimosa-minimal"
 
-{ config, ... }:
+{ config, lib, ... }:
 
+let
+  cfg = config.mimosa.webserver;
+in
 {
-  # Configuration du service j12z-webserver
-  services.j12z-webserver = {
-    enable = true;
-    domain = "jeremiealcaraz.com";
-    email = "hello@jeremiealcaraz.com";
-    # Cloudflare Tunnel activé avec sops
-    enableCloudflaredTunnel = true;
-    cloudflaredTokenFile = config.sops.secrets.cloudflare-tunnel-token.path;
-  };
+  options.mimosa.webserver.enable = lib.mkEnableOption "the j12z webserver for mimosa";
 
-  # Secret Cloudflare Tunnel (uniquement nécessaire pour la config complète)
-  sops.secrets.cloudflare-tunnel-token = {
-    owner = "cloudflared";
-    group = "cloudflared";
-    mode = "0400";
+  config = lib.mkIf cfg.enable {
+    # Configuration du service j12z-webserver
+    services.j12z-webserver = {
+      enable = true;
+      domain = "jeremiealcaraz.com";
+      email = "hello@jeremiealcaraz.com";
+      # Cloudflare Tunnel activé avec sops
+      enableCloudflaredTunnel = true;
+      cloudflaredTokenFile = config.sops.secrets.cloudflare-tunnel-token.path;
+    };
+
+    # Secret Cloudflare Tunnel (uniquement nécessaire pour la config complète)
+    sops.secrets.cloudflare-tunnel-token = {
+      owner = "cloudflared";
+      group = "cloudflared";
+      mode = "0400";
+    };
   };
 }


### PR DESCRIPTION
## Summary
- add a dedicated enable option to the mimosa webserver module so it can be toggled easily
- disable the webserver by default in the mimosa host configuration to avoid j12zdotcom builds for now

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f520a03b4832f837528dfc4f2c137)