### PR TITLE
Rename tailscale oauth join service

### DIFF
--- a/modules/tailscale.nix
+++ b/modules/tailscale.nix
@@ -1,7 +1,7 @@
 ({ config, pkgs, lib, ... }:
 let
   # Script qui gère l'authentification OAuth et la connexion à Tailscale
-  tailscaleAuthScript = pkgs.writeShellScript "tailscale-oauth-join" ''
+  tailscaleAuthScript = pkgs.writeShellScript "tailscale" ''
     set -euo pipefail  # Arrête le script dès la première erreur
 
     # === RÉCUPÉRATION DES SECRETS ===
@@ -70,7 +70,7 @@ in
 {
   # === SERVICE SYSTEMD ===
   # Ce service s'exécute automatiquement au démarrage de la machine
-  systemd.services.tailscale-oauth-join = {
+  systemd.services.tailscale = {
     description = "Tailscale OAuth Auto-Join";
     
     # === DÉPENDANCES : Quand démarrer le service ? ===


### PR DESCRIPTION
## Summary
- rename the Tailscale OAuth join script and systemd service from tailscale-oauth-join to tailscale

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f552c652c832f87cbbb5a624cd80d)