### PR TITLE
Add base module to provide jq on all VMs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
         magnolia = nixpkgs.lib.nixosSystem {
           inherit system;
           modules = [
+            ./modules/base.nix
             ./hosts/magnolia/configuration.nix
             sops-nix.nixosModules.sops
             home-manager.nixosModules.home-manager
@@ -42,6 +43,7 @@
         mimosa-minimal = nixpkgs.lib.nixosSystem {
           inherit system;
           modules = [
+            ./modules/base.nix
             ./hosts/mimosa/configuration.nix
             sops-nix.nixosModules.sops
             home-manager.nixosModules.home-manager
@@ -59,6 +61,7 @@
         mimosa = nixpkgs.lib.nixosSystem {
           inherit system;
           modules = [
+            ./modules/base.nix
             ./hosts/mimosa/configuration.nix
             ./hosts/mimosa/webserver.nix  # Configuration du serveur web
             j12z-site.nixosModules.j12z-webserver
@@ -76,6 +79,7 @@
         whitelily = nixpkgs.lib.nixosSystem {
           inherit system;
           modules = [
+            ./modules/base.nix
             ./hosts/whitelily/configuration.nix
             sops-nix.nixosModules.sops
             home-manager.nixosModules.home-manager
@@ -91,6 +95,7 @@
         demo = nixpkgs.lib.nixosSystem {
           inherit system;
           modules = [
+            ./modules/base.nix
             ./hosts/demo/configuration.nix
           ];
         };

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -1,0 +1,14 @@
+# ============================================================================
+# Module commun "base.nix"
+# ---------------------------------------------------------------------------
+# Ce module est chargé sur toutes les machines virtuelles définies dans ce
+# dépôt. Il regroupe les paquets système de base qui doivent être présents
+# partout pour l'administration et le débogage. Actuellement, il assure
+# l'installation de `jq` pour manipuler facilement du JSON depuis la ligne de
+# commande.
+# ============================================================================
+
+{ pkgs, ... }:
+{
+  environment.systemPackages = [ pkgs.jq ];
+}


### PR DESCRIPTION
## Summary
- add a shared base NixOS module that ensures jq is installed everywhere
- include the new base module in every VM configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f652d87d0832f868a34f499d4ceea)