### PR TITLE
Update Tailscale tag configuration

### DIFF
--- a/modules/tailscale.nix
+++ b/modules/tailscale.nix
@@ -48,7 +48,7 @@ let
       "create": {
         "reusable": false,
         "ephemeral": false,
-        "tags": ["tag:server", "tag:nixos"],
+        "tags": ["newmachine"],
         "preauthorized": true
       }
     }


### PR DESCRIPTION
## Summary
- set the Tailscale auth key creation payload to use only the "newmachine" tag

## Testing
- `nix flake check` *(fails: nix command not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f690511a4832faacaad9d8c3d2c03)