### PR TITLE
Fix git permission denied error on NixOS

### DIFF
--- a/hosts/demo/configuration.nix
+++ b/hosts/demo/configuration.nix
@@ -61,5 +61,6 @@
   users.users.jeremie.shell = pkgs.zsh;
 
   # Paquets système essentiels
-  environment.systemPackages = with pkgs; [ git curl wget ];
+  # Note: git est maintenant géré par modules/git.nix (importé via base.nix)
+  environment.systemPackages = with pkgs; [ curl wget ];
 }

--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -106,5 +106,6 @@
   users.users.jeremie.shell = pkgs.zsh;
 
   # Paquets système essentiels
-  environment.systemPackages = with pkgs; [ git curl wget ];
+  # Note: git est maintenant géré par modules/git.nix (importé via base.nix)
+  environment.systemPackages = with pkgs; [ curl wget ];
 }

--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -111,8 +111,8 @@
   users.users.jeremie.shell = pkgs.fish;
 
   # Paquets système essentiels
+  # Note: git est maintenant géré par modules/git.nix (importé via base.nix)
   environment.systemPackages = with pkgs; [
-    git
     curl
     wget
   ];

--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -147,8 +147,8 @@
   programs.tmux.enable = true;
 
   # Paquets système essentiels
+  # Note: git est maintenant géré par modules/git.nix (importé via base.nix)
   environment.systemPackages = with pkgs; [
-    git
     curl
     wget
     htop

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -4,11 +4,15 @@
 # Ce module est chargé sur toutes les machines virtuelles définies dans ce
 # dépôt. Il regroupe les paquets système de base qui doivent être présents
 # partout pour l'administration et le débogage. Actuellement, il assure
-# l'installation de `jq` pour manipuler facilement du JSON depuis la ligne de
-# commande.
+# l'installation de `jq` et de `git`, ainsi que la gestion déclarative des
+# permissions du dépôt nix-config.
 # ============================================================================
 
 { pkgs, ... }:
 {
+  imports = [
+    ./git.nix
+  ];
+
   environment.systemPackages = [ pkgs.jq ];
 }

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -1,0 +1,92 @@
+# ============================================================================
+# Module "git.nix"
+# ---------------------------------------------------------------------------
+# Ce module centralise toute la configuration Git pour le système NixOS.
+# Il garantit que Git est installé et configuré correctement, et que les
+# dépôts ont les bonnes permissions.
+# ============================================================================
+
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.nixConfig or {};
+  # Chemin standard du dépôt NixOS (peut être surchargé si besoin pour des cas particuliers)
+  repoPath = cfg.repoPath or "/etc/nixos";
+  # Propriétaire par défaut (peut être surchargé par nixConfig.repoOwner)
+  repoOwner = cfg.repoOwner or "jeremie";
+in
+{
+  # =========================================================================
+  # OPTIONS DE CONFIGURATION
+  # =========================================================================
+
+  options = {
+    nixConfig = {
+      repoPath = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Chemin du dépôt nix-config à gérer.
+          Par défaut: /etc/nixos (emplacement standard NixOS)
+          Utile uniquement si vous avez un setup non-standard.
+        '';
+        example = "/home/jeremie/dev/nix-config";
+      };
+
+      repoOwner = lib.mkOption {
+        type = lib.types.str;
+        default = "jeremie";
+        description = "Utilisateur propriétaire du dépôt";
+        example = "jeremie";
+      };
+    };
+  };
+
+  # =========================================================================
+  # CONFIGURATION GIT SYSTÈME
+  # =========================================================================
+
+  config = {
+    # Installation de Git au niveau système
+    environment.systemPackages = with pkgs; [
+      git
+    ];
+
+    # Configuration Git globale (système)
+    # Vous pouvez ajouter ici d'autres paramètres Git si nécessaire
+    # environment.etc."gitconfig".text = ''
+    #   [core]
+    #     editor = vim
+    #   [init]
+    #     defaultBranch = main
+    # '';
+
+    # =========================================================================
+    # GESTION DÉCLARATIVE DES PERMISSIONS DU DÉPÔT
+    # =========================================================================
+    #
+    # Problème résolu :
+    # Lorsque des opérations système (comme sudo, nix-build, ou certains
+    # services) modifient des fichiers dans le dépôt Git, ils peuvent changer
+    # le propriétaire en 'root', causant des erreurs "Permission denied" lors
+    # de l'utilisation de Git.
+    #
+    # Solution :
+    # Utilise systemd.tmpfiles.rules pour appliquer automatiquement les bonnes
+    # permissions à chaque boot et à chaque activation de configuration.
+    # Cette approche est déclarative et s'intègre parfaitement à NixOS.
+    #
+    # Format systemd.tmpfiles : Type Path Mode UID GID Age Argument
+    # Z = Set ownership and access mode recursively (récursif)
+    # =========================================================================
+
+    systemd.tmpfiles.rules = [
+      # Fixe les permissions du dépôt nix-config récursivement
+      "Z ${repoPath} 0755 ${repoOwner} users - -"
+
+      # Assure que le répertoire .git a les bonnes permissions
+      # (Important car Git écrit souvent dans .git/FETCH_HEAD, index, etc.)
+      "Z ${repoPath}/.git 0755 ${repoOwner} users - -"
+    ];
+  };
+}


### PR DESCRIPTION
Creates a dedicated Git module that manages Git installation and repository permissions declaratively across all systems.

Changes:
- New module: modules/git.nix
  - Centralizes all Git-related configuration
  - Handles Git package installation
  - Configurable repo path and owner via nixConfig options
  - Uses systemd.tmpfiles to fix permissions declaratively
  - Extensive documentation and comments
  - Applied at boot and system activation

- Updated modules/base.nix
  - Import git.nix instead of separate module
  - Updated documentation

- Cleaned up host configurations
  - Removed redundant git declarations in:
    * hosts/mimosa/configuration.nix
    * hosts/magnolia/configuration.nix
    * hosts/whitelily/configuration.nix
    * hosts/demo/configuration.nix
  - Git now managed centrally via base.nix

Problem solved:
Prevents "Permission denied" errors when running git commands after system operations that change file ownership to root.

Default configuration:
- repoPath: /etc/nixos (standard NixOS location)
- repoOwner: jeremie

Can be customized per-host if needed:
  nixConfig.repoPath = "/custom/path"; nixConfig.repoOwner = "username";