### PR TITLE
Fix SSH connection broken by Tailscale

### DIFF
--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -102,9 +102,9 @@
   # Tailscale
   services.tailscale = {
     enable = true;
-    useRoutingFeatures = "client";
-    # Port pour SSH via Tailscale (par défaut Tailscale gère SSH)
-    openFirewall = true;
+    useRoutingFeatures = "none";
+    # openFirewall géré par networking.firewall au-dessus
+    openFirewall = false;
   };
 
   # Fish activé au niveau système (requis pour users.users.jeremie.shell)

--- a/modules/tailscale.nix
+++ b/modules/tailscale.nix
@@ -86,11 +86,11 @@ EOF
     # === CONNEXION À TAILSCALE ===
     # --auth-key : utilise la clé qu'on vient de générer
     # --hostname : définit le nom de la machine dans le réseau Tailscale
-    # --accept-routes : accepte les routes du réseau (subnet routing)
+    # --accept-dns=false : n'accepte pas le DNS Tailscale pour éviter les conflits
     ${pkgs.tailscale}/bin/tailscale up \
       --auth-key="$AUTH_KEY" \
       --hostname="${config.networking.hostName}" \
-      --accept-routes
+      --accept-dns=false
 
     log "🎉 Machine ${config.networking.hostName} connectée à Tailscale !"
   '';


### PR DESCRIPTION
Tailscale était configuré pour accepter les routes du réseau et utiliser les fonctionnalités de routage avancées, ce qui causait un conflit avec le réseau local (192.168.1.x). La machine devenait inaccessible via son IP locale quand Tailscale était actif.

Changements :
- Suppression de --accept-routes dans le script d'authentification
- Ajout de --accept-dns=false pour éviter les conflits DNS
- Désactivation de useRoutingFeatures (none au lieu de client)
- Désactivation de openFirewall (déjà géré au niveau système)

Cela permet à Tailscale de fonctionner sans interférer avec l'accès SSH et ping via le réseau local.