### PR TITLE
Add --reset flag to Tailscale up command

### DIFF
--- a/modules/tailscale.nix
+++ b/modules/tailscale.nix
@@ -84,10 +84,12 @@ EOF
     log "✅ Auth key générée, connexion à Tailscale..."
 
     # === CONNEXION À TAILSCALE ===
+    # --reset : réinitialise tous les paramètres à leurs valeurs par défaut
     # --auth-key : utilise la clé qu'on vient de générer
     # --hostname : définit le nom de la machine dans le réseau Tailscale
     # --accept-dns=false : n'accepte pas le DNS Tailscale pour éviter les conflits
     ${pkgs.tailscale}/bin/tailscale up \
+      --reset \
       --auth-key="$AUTH_KEY" \
       --hostname="${config.networking.hostName}" \
       --accept-dns=false


### PR DESCRIPTION
Tailscale refuse de changer les paramètres si la machine était déjà connectée avec des flags différents. Le flag --reset force la réinitialisation de tous les paramètres à leurs valeurs par défaut, permettant ainsi d'appliquer la nouvelle configuration sans erreur.

Cela résout l'erreur :
"Error: changing settings via 'tailscale up' requires mentioning all non-default flags. To proceed, either re-run your command with --reset"