### PR TITLE
Fix NixOS system rebuild Git tree error

### DIFF
--- a/modules/git.nix
+++ b/modules/git.nix
@@ -23,8 +23,8 @@ in
   options = {
     nixConfig = {
       repoPath = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
+        type = lib.types.str;
+        default = "/etc/nixos";
         description = ''
           Chemin du dépôt nix-config à gérer.
           Par défaut: /etc/nixos (emplacement standard NixOS)


### PR DESCRIPTION
- Changed repoPath default from null to '/etc/nixos'
- Removed nullOr type constraint since the option should always have a value
- This fixes the 'cannot coerce null to a string' error during nixos-rebuild