### PR TITLE
Align SSH and Tailscale configuration across hosts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,7 @@
           modules = [
             ./modules/base.nix
             ./hosts/demo/configuration.nix
+            sops-nix.nixosModules.sops
           ];
         };
 

--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -1,7 +1,10 @@
 { config, pkgs, ... }:
 
 {
-  imports = [ ./hardware-configuration.nix ];
+  imports = [
+    ./hardware-configuration.nix
+    ../../modules/tailscale.nix
+  ];
 
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
@@ -19,7 +22,10 @@
   # Réseau
   networking.hostName = "magnolia";  # Infrastructure Proxmox
   networking.useDHCP = true;
-  networking.firewall.enable = false;
+  networking.firewall = {
+    enable = true;
+    allowedTCPPorts = [ 22 ];
+  };
   # Désactiver resolvconf (DHCP gère déjà le DNS)
   networking.resolvconf.enable = false;
 
@@ -32,13 +38,11 @@
     PermitRootLogin = "no";
   };
 
-  # 👉 Choisis UNE des 2 options ci-dessous (A ou B). Laisse l’autre commentée.
-
-  ## === Option A: /etc/ssh/authorized_keys.d/jeremie (recommandée) ===
   services.openssh.authorizedKeysFiles = [
     "/etc/ssh/authorized_keys.d/%u"
     "~/.ssh/authorized_keys"
   ];
+
   environment.etc."ssh/authorized_keys.d/jeremie" = {
     text = ''
       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac
@@ -47,20 +51,6 @@
   };
 
   users.mutableUsers = false;
-
-  ## === Option B: ~/.ssh/authorized_keys (alternative classique) ===
-  # users.users.jeremie = {
-  #   isNormalUser = true;
-  #   createHome = true;
-  #   home = "/home/jeremie";
-  #   extraGroups = [ "wheel" ];
-  #   password = null;
-  #   openssh.authorizedKeys.keys = [
-  #     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac"
-  #   ];
-  # };
-
-  # Si tu utilises l'Option A, définis tout de même l'utilisateur :
   users.users.jeremie = {
     isNormalUser = true;
     createHome = true;
@@ -80,6 +70,12 @@
 
   # QEMU Guest Agent
   services.qemuGuest.enable = true;
+
+  services.tailscale = {
+    enable = true;
+    useRoutingFeatures = "none";
+    openFirewall = false;
+  };
 
   # Configuration sops-nix pour la gestion des secrets
   sops = {

--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -4,7 +4,8 @@
   imports = [
     ./hardware-configuration.nix
     ./n8n.nix
-    ./n8n-backup.nix 
+    ./n8n-backup.nix
+    ../../modules/tailscale.nix
 
   ];
 
@@ -27,8 +28,10 @@
   # Configuration DNS (resolvconf désactivé, donc configuration manuelle)
   networking.nameservers = [ "8.8.8.8" "1.1.1.1" ];
   # Firewall activé (Cloudflare Tunnel = trafic sortant uniquement)
-  networking.firewall.enable = true;
-  networking.firewall.allowedTCPPorts = [ ]; # Aucun port public ouvert
+  networking.firewall = {
+    enable = true;
+    allowedTCPPorts = [ 22 ]; # SSH uniquement (Cloudflare Tunnel = trafic sortant)
+  };
 
   # SSH
   services.openssh.enable = true;
@@ -39,11 +42,12 @@
     PermitRootLogin = "no";
   };
 
-  # Clés SSH autorisées
   services.openssh.authorizedKeysFiles = [
     "/etc/ssh/authorized_keys.d/%u"
     "~/.ssh/authorized_keys"
   ];
+
+  # Clés SSH autorisées
   environment.etc."ssh/authorized_keys.d/jeremie" = {
     text = ''
       ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac
@@ -73,6 +77,12 @@
 
   # QEMU Guest Agent
   services.qemuGuest.enable = true;
+
+  services.tailscale = {
+    enable = true;
+    useRoutingFeatures = "none";
+    openFirewall = false;
+  };
 
   # Configuration sops-nix pour la gestion des secrets
   sops = {


### PR DESCRIPTION
## Summary
- align the SSH hardening and firewall rules on magnolia, whitelily, and demo with the mimosa configuration
- enable the shared Tailscale module on all hosts and add the required settings per host
- register sops-nix for the demo system so it can decrypt shared Tailscale secrets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69206b34ca14832fb926274fe6ae2642)