### PR TITLE
Add shared SSH module

### DIFF
--- a/hosts/demo/configuration.nix
+++ b/hosts/demo/configuration.nix
@@ -4,21 +4,12 @@
 {
   imports = [
     ./hardware-configuration.nix
+    ../../modules/ssh.nix
     ../../modules/tailscale.nix
   ];
 
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-
-  # Console série Proxmox
-  boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty1" ];
-  console.earlySetup = true;
-
   time.timeZone = "Europe/Paris";
   system.stateVersion = "25.05";
-
-  # Activer les flakes et nix-command
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   # Réseau
   networking.hostName = "demo";
@@ -28,44 +19,6 @@
     allowedTCPPorts = [ 22 ];
   };
   networking.resolvconf.enable = false;
-
-  # SSH
-  services.openssh.enable = true;
-  services.openssh.settings = {
-    PasswordAuthentication = false;
-    KbdInteractiveAuthentication = false;
-    PubkeyAuthentication = true;
-    PermitRootLogin = "no";
-  };
-
-  services.openssh.authorizedKeysFiles = [
-    "/etc/ssh/authorized_keys.d/%u"
-    "~/.ssh/authorized_keys"
-  ];
-
-  # Utilisateurs immuables
-  users.mutableUsers = false;
-
-  # Clés SSH autorisées pour jeremie
-  environment.etc."ssh/authorized_keys.d/jeremie" = {
-    text = ''
-      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac
-    '';
-    mode = "0644";
-  };
-
-  # Utilisateur jeremie (pas de mot de passe, SSH uniquement)
-  users.users.jeremie = {
-    isNormalUser = true;
-    createHome = true;
-    home = "/home/jeremie";
-    extraGroups = [ "wheel" ];
-    password = null;
-  };
-
-  # Sudo sans mot de passe (sécurisé car SSH par clé uniquement)
-  security.sudo.enable = true;
-  security.sudo.wheelNeedsPassword = false;
 
   # QEMU Guest Agent
   services.qemuGuest.enable = true;
@@ -82,14 +35,4 @@
     age.keyFile = "/var/lib/sops-nix/key.txt";
   };
 
-  # ZSH activé au niveau système
-  programs.zsh.enable = true;
-  programs.tmux.enable = true;
-
-  # Shell par défaut pour jeremie
-  users.users.jeremie.shell = pkgs.zsh;
-
-  # Paquets système essentiels
-  # Note: git est maintenant géré par modules/git.nix (importé via base.nix)
-  environment.systemPackages = with pkgs; [ curl wget ];
 }

--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -3,21 +3,12 @@
 {
   imports = [
     ./hardware-configuration.nix
+    ../../modules/ssh.nix
     ../../modules/tailscale.nix
   ];
 
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-
-  # Console série Proxmox
-  boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty1" ];
-  console.earlySetup = true;
-
   time.timeZone = "Europe/Paris";
   system.stateVersion = "25.05";
-
-  # Activer les flakes et nix-command
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   # Réseau
   networking.hostName = "magnolia";  # Infrastructure Proxmox
@@ -29,44 +20,7 @@
   # Désactiver resolvconf (DHCP gère déjà le DNS)
   networking.resolvconf.enable = false;
 
-  # SSH
-  services.openssh.enable = true;
-  services.openssh.settings = {
-    PasswordAuthentication = false;
-    KbdInteractiveAuthentication = false;
-    PubkeyAuthentication = true;
-    PermitRootLogin = "no";
-  };
-
-  services.openssh.authorizedKeysFiles = [
-    "/etc/ssh/authorized_keys.d/%u"
-    "~/.ssh/authorized_keys"
-  ];
-
-  environment.etc."ssh/authorized_keys.d/jeremie" = {
-    text = ''
-      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac
-    '';
-    mode = "0644";
-  };
-
-  users.mutableUsers = false;
-  users.users.jeremie = {
-    isNormalUser = true;
-    createHome = true;
-    home = "/home/jeremie";
-    extraGroups = [ "wheel" ];
-    # Hash du mot de passe stocké de manière sécurisée dans sops
-    # Le fichier de secrets est chiffré et ne peut être déchiffré que par l'hôte
-    hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
-  };
-
-  # Root sans mot de passe (SSH root déjà interdit)
-  users.users.root.password = null;
-
-  # Sudo - Permet au groupe wheel d'exécuter toutes les commandes sans mot de passe
-  security.sudo.enable = true;
-  security.sudo.wheelNeedsPassword = false;
+  sshCommon.jeremieHashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
 
   # QEMU Guest Agent
   services.qemuGuest.enable = true;
@@ -91,17 +45,4 @@
     };
   };
 
-  # ZSH activé au niveau système (requis pour users.users.jeremie.shell)
-  # La configuration ZSH détaillée est gérée par Home Manager
-  programs.zsh.enable = true;
-
-  # Tmux au niveau système
-  programs.tmux.enable = true;
-
-  # Shell par défaut pour l'utilisateur jeremie
-  users.users.jeremie.shell = pkgs.zsh;
-
-  # Paquets système essentiels
-  # Note: git est maintenant géré par modules/git.nix (importé via base.nix)
-  environment.systemPackages = with pkgs; [ curl wget ];
 }

--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -1,26 +1,16 @@
 { config, pkgs, ... }:
 
 {
- imports = [
+  imports = [
     ./hardware-configuration.nix
+    ../../modules/ssh.nix
     ../../modules/tailscale.nix  # <--- AJOUTE ÇA
     # ... tes autres imports
   ];
 
-  # Boot
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-
-  # Console série pour VM Proxmox
-  boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty1" ];
-  console.earlySetup = true;
-
   # Système
   time.timeZone = "Europe/Paris";
   system.stateVersion = "24.05";
-
-  # Activer les flakes et nix-command
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   # Réseau
   networking.hostName = "mimosa";  # Serveur web
@@ -32,45 +22,11 @@
     # Les autres ports (80, 443) seront ouverts par j12z-webserver
   };
 
-  # SSH
-  services.openssh.enable = true;
-  services.openssh.settings = {
-    PasswordAuthentication = false;
-    KbdInteractiveAuthentication = false;
-    PubkeyAuthentication = true;
-    PermitRootLogin = "no";
+  sshCommon = {
+    jeremieShell = pkgs.fish;
+    jeremieHashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
+    enableTmux = false;
   };
-
-  # Configuration SSH pour l'utilisateur jeremie
-  services.openssh.authorizedKeysFiles = [
-    "/etc/ssh/authorized_keys.d/%u"
-    "~/.ssh/authorized_keys"
-  ];
-
-  environment.etc."ssh/authorized_keys.d/jeremie" = {
-    text = ''
-      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac
-    '';
-    mode = "0644";
-  };
-
-  # Utilisateur
-  users.users.jeremie = {
-    isNormalUser = true;
-    createHome = true;
-    home = "/home/jeremie";
-    extraGroups = [ "wheel" ];
-    # Hash du mot de passe stocké de manière sécurisée dans sops
-    # Le fichier de secrets est chiffré et ne peut être déchiffré que par l'hôte
-    hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
-  };
-
-  # Root sans mot de passe (SSH root déjà interdit)
-  users.users.root.password = null;
-
-  # Sudo sans mot de passe pour le groupe wheel (sécurisé car SSH par clé uniquement)
-  security.sudo.enable = true;
-  security.sudo.wheelNeedsPassword = false;
 
   # QEMU Guest Agent pour Proxmox
   services.qemuGuest.enable = true;
@@ -109,15 +65,4 @@
 
   # Fish activé au niveau système (requis pour users.users.jeremie.shell)
   # La configuration Fish détaillée est gérée par Home Manager
-  programs.fish.enable = true;
-
-  # Shell par défaut pour l'utilisateur jeremie
-  users.users.jeremie.shell = pkgs.fish;
-
-  # Paquets système essentiels
-  # Note: git est maintenant géré par modules/git.nix (importé via base.nix)
-  environment.systemPackages = with pkgs; [
-    curl
-    wget
-  ];
 }

--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -5,22 +5,13 @@
     ./hardware-configuration.nix
     ./n8n.nix
     ./n8n-backup.nix
+    ../../modules/ssh.nix
     ../../modules/tailscale.nix
 
   ];
 
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-
-  # Console série Proxmox
-  boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty1" ];
-  console.earlySetup = true;
-
   time.timeZone = "Europe/Paris";
   system.stateVersion = "25.05";
-
-  # Activer les flakes et nix-command
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   # Réseau
   networking.hostName = "whitelily";  # VM n8n automation
@@ -33,47 +24,10 @@
     allowedTCPPorts = [ 22 ]; # SSH uniquement (Cloudflare Tunnel = trafic sortant)
   };
 
-  # SSH
-  services.openssh.enable = true;
-  services.openssh.settings = {
-    PasswordAuthentication = false;
-    KbdInteractiveAuthentication = false;
-    PubkeyAuthentication = true;
-    PermitRootLogin = "no";
+  sshCommon = {
+    jeremieHashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
+    extraPackages = with pkgs; [ htop restic gzip ];
   };
-
-  services.openssh.authorizedKeysFiles = [
-    "/etc/ssh/authorized_keys.d/%u"
-    "~/.ssh/authorized_keys"
-  ];
-
-  # Clés SSH autorisées
-  environment.etc."ssh/authorized_keys.d/jeremie" = {
-    text = ''
-      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac
-    '';
-    mode = "0644";
-  };
-
-  users.mutableUsers = false;
-
-  # Utilisateur jeremie
-  users.users.jeremie = {
-    isNormalUser = true;
-    createHome = true;
-    home = "/home/jeremie";
-    extraGroups = [ "wheel" ];
-    # Hash du mot de passe stocké de manière sécurisée dans sops
-    hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
-    shell = pkgs.zsh;
-  };
-
-  # Root sans mot de passe (SSH root déjà interdit)
-  users.users.root.password = null;
-
-  # Sudo - Permet au groupe wheel d'exécuter toutes les commandes sans mot de passe
-  security.sudo.enable = true;
-  security.sudo.wheelNeedsPassword = false;
 
   # QEMU Guest Agent
   services.qemuGuest.enable = true;
@@ -151,18 +105,4 @@
 
   # ZSH activé au niveau système (requis pour users.users.jeremie.shell)
   # La configuration ZSH détaillée est gérée par Home Manager
-  programs.zsh.enable = true;
-
-  # Tmux au niveau système
-  programs.tmux.enable = true;
-
-  # Paquets système essentiels
-  # Note: git est maintenant géré par modules/git.nix (importé via base.nix)
-  environment.systemPackages = with pkgs; [
-    curl
-    wget
-    htop
-    restic  # Pour les backups
-    gzip
-  ];
 }

--- a/modules/ssh.nix
+++ b/modules/ssh.nix
@@ -1,0 +1,132 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkIf mkMerge mkOption optional types;
+  cfg = config.sshCommon;
+
+  defaultJeremieKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac";
+
+  jeremiePasswordAttrs =
+    if cfg.jeremieHashedPasswordFile != null then
+      { hashedPasswordFile = cfg.jeremieHashedPasswordFile; }
+    else
+      { password = cfg.jeremiePassword; };
+
+  jeremieAuthorizedKeys = [ defaultJeremieKey ] ++ cfg.extraAuthorizedKeys;
+
+in {
+  options.sshCommon = {
+    sshPort = mkOption {
+      type = types.port;
+      default = 22;
+      description = "Port SSH principal à ouvrir dans le pare-feu.";
+    };
+
+    authorizedKeysFiles = mkOption {
+      type = types.listOf types.str;
+      default = [ "/etc/ssh/authorized_keys.d/%u" "~/.ssh/authorized_keys" ];
+      description = "Emplacements des fichiers de clés autorisées pour OpenSSH.";
+    };
+
+    extraAuthorizedKeys = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Clés SSH supplémentaires autorisées pour l'utilisateur jeremie.";
+    };
+
+    jeremieShell = mkOption {
+      type = types.package;
+      default = pkgs.zsh;
+      description = "Shell par défaut pour l'utilisateur jeremie.";
+    };
+
+    jeremiePassword = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Mot de passe en clair pour l'utilisateur jeremie (par défaut aucun).";
+    };
+
+    jeremieHashedPasswordFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Fichier contenant le mot de passe haché de l'utilisateur jeremie.";
+    };
+
+    extraSshdSettings = mkOption {
+      type = types.attrsOf types.unspecified;
+      default = { };
+      description = "Paramètres supplémentaires à fusionner dans services.openssh.settings.";
+    };
+
+    extraPackages = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      description = "Paquets supplémentaires à installer à côté des utilitaires de base.";
+    };
+
+    enableTmux = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Active tmux et l'ajoute aux paquets système.";
+    };
+  };
+
+  config = {
+    boot.loader.systemd-boot.enable = true;
+    boot.loader.efi.canTouchEfiVariables = true;
+
+    # Console série Proxmox
+    boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty1" ];
+    console.earlySetup = true;
+
+    # Activer les flakes et nix-command
+    nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
+    networking.firewall.allowedTCPPorts = [ cfg.sshPort ];
+
+    services.openssh = {
+      enable = true;
+      settings = mkMerge [
+        {
+          PasswordAuthentication = false;
+          KbdInteractiveAuthentication = false;
+          PubkeyAuthentication = true;
+          PermitRootLogin = "no";
+        }
+        cfg.extraSshdSettings
+      ];
+      authorizedKeysFiles = cfg.authorizedKeysFiles;
+    };
+
+    users.mutableUsers = false;
+
+    environment.etc."ssh/authorized_keys.d/jeremie" = {
+      text = lib.concatStringsSep "\n" jeremieAuthorizedKeys;
+      mode = "0644";
+    };
+
+    users.users.jeremie = {
+      isNormalUser = true;
+      createHome = true;
+      home = "/home/jeremie";
+      extraGroups = [ "wheel" ];
+      shell = cfg.jeremieShell;
+    } // jeremiePasswordAttrs;
+
+    # Root sans mot de passe (SSH root déjà interdit)
+    users.users.root.password = null;
+
+    # Sudo - Permet au groupe wheel d'exécuter toutes les commandes sans mot de passe
+    security.sudo.enable = true;
+    security.sudo.wheelNeedsPassword = false;
+
+    programs.tmux.enable = cfg.enableTmux;
+    programs.zsh.enable = mkIf (cfg.jeremieShell == pkgs.zsh) true;
+    programs.fish.enable = mkIf (cfg.jeremieShell == pkgs.fish) true;
+
+    environment.systemPackages = with pkgs;
+      [ curl wget ]
+      ++ optional cfg.enableTmux pkgs.tmux
+      ++ cfg.extraPackages;
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable ssh module centralizing boot, nix settings, SSH hardening, and user defaults
- allow hosts to override SSH options such as ports, keys, shell, and extra packages
- simplify each host configuration to import the new module and keep host-specific data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69207202f664832f8edbf9a1835ab106)