### PR TITLE
Centralize shared host defaults into base and ssh modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
           inherit system;
           modules = [
             ./modules/base.nix
+            ./modules/ssh.nix
             ./hosts/magnolia/configuration.nix
             sops-nix.nixosModules.sops
             home-manager.nixosModules.home-manager
@@ -44,6 +45,7 @@
           inherit system;
           modules = [
             ./modules/base.nix
+            ./modules/ssh.nix
             ./hosts/mimosa/configuration.nix
             sops-nix.nixosModules.sops
             home-manager.nixosModules.home-manager
@@ -62,6 +64,7 @@
           inherit system;
           modules = [
             ./modules/base.nix
+            ./modules/ssh.nix
             ./hosts/mimosa/configuration.nix
             ./hosts/mimosa/webserver.nix  # Configuration du serveur web
             j12z-site.nixosModules.j12z-webserver
@@ -80,6 +83,7 @@
           inherit system;
           modules = [
             ./modules/base.nix
+            ./modules/ssh.nix
             ./hosts/whitelily/configuration.nix
             sops-nix.nixosModules.sops
             home-manager.nixosModules.home-manager
@@ -96,6 +100,7 @@
           inherit system;
           modules = [
             ./modules/base.nix
+            ./modules/ssh.nix
             ./hosts/demo/configuration.nix
             sops-nix.nixosModules.sops
           ];

--- a/hosts/demo/configuration.nix
+++ b/hosts/demo/configuration.nix
@@ -7,68 +7,17 @@
     ../../modules/tailscale.nix
   ];
 
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-
-  # Console série Proxmox
-  boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty1" ];
-  console.earlySetup = true;
-
-  time.timeZone = "Europe/Paris";
   system.stateVersion = "25.05";
-
-  # Activer les flakes et nix-command
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   # Réseau
   networking.hostName = "demo";
   networking.useDHCP = true;
-  networking.firewall = {
-    enable = true;
-    allowedTCPPorts = [ 22 ];
-  };
   networking.resolvconf.enable = false;
-
-  # SSH
-  services.openssh.enable = true;
-  services.openssh.settings = {
-    PasswordAuthentication = false;
-    KbdInteractiveAuthentication = false;
-    PubkeyAuthentication = true;
-    PermitRootLogin = "no";
-  };
-
-  services.openssh.authorizedKeysFiles = [
-    "/etc/ssh/authorized_keys.d/%u"
-    "~/.ssh/authorized_keys"
-  ];
-
-  # Utilisateurs immuables
-  users.mutableUsers = false;
-
-  # Clés SSH autorisées pour jeremie
-  environment.etc."ssh/authorized_keys.d/jeremie" = {
-    text = ''
-      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac
-    '';
-    mode = "0644";
-  };
 
   # Utilisateur jeremie (pas de mot de passe, SSH uniquement)
   users.users.jeremie = {
-    isNormalUser = true;
-    createHome = true;
-    home = "/home/jeremie";
-    extraGroups = [ "wheel" ];
     password = null;
   };
-
-  # Sudo sans mot de passe (sécurisé car SSH par clé uniquement)
-  security.sudo.enable = true;
-  security.sudo.wheelNeedsPassword = false;
-
-  # QEMU Guest Agent
-  services.qemuGuest.enable = true;
 
   services.tailscale = {
     enable = true;
@@ -81,20 +30,4 @@
     defaultSopsFile = ../../secrets/common.yaml;
     age.keyFile = "/var/lib/sops-nix/key.txt";
   };
-
-  # Fish activé au niveau système (requis pour users.users.jeremie.shell)
-  # La configuration Fish détaillée est gérée par Home Manager
-  programs.fish.enable = true;
-
-  # ZSH - Commenté (remplacé par Fish)
-  # programs.zsh.enable = true;
-
-  programs.tmux.enable = true;
-
-  # Shell par défaut pour jeremie
-  users.users.jeremie.shell = pkgs.fish;
-
-  # Paquets système essentiels
-  # Note: git est maintenant géré par modules/git.nix (importé via base.nix)
-  environment.systemPackages = with pkgs; [ curl wget ];
 }

--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -6,70 +6,18 @@
     ../../modules/tailscale.nix
   ];
 
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-
-  # Console série Proxmox
-  boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty1" ];
-  console.earlySetup = true;
-
-  time.timeZone = "Europe/Paris";
   system.stateVersion = "25.05";
-
-  # Activer les flakes et nix-command
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   # Réseau
   networking.hostName = "magnolia";  # Infrastructure Proxmox
   networking.useDHCP = true;
-  networking.firewall = {
-    enable = true;
-    allowedTCPPorts = [ 22 ];
-  };
   # Désactiver resolvconf (DHCP gère déjà le DNS)
   networking.resolvconf.enable = false;
-
-  # SSH
-  services.openssh.enable = true;
-  services.openssh.settings = {
-    PasswordAuthentication = false;
-    KbdInteractiveAuthentication = false;
-    PubkeyAuthentication = true;
-    PermitRootLogin = "no";
-  };
-
-  services.openssh.authorizedKeysFiles = [
-    "/etc/ssh/authorized_keys.d/%u"
-    "~/.ssh/authorized_keys"
-  ];
-
-  environment.etc."ssh/authorized_keys.d/jeremie" = {
-    text = ''
-      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac
-    '';
-    mode = "0644";
-  };
-
-  users.mutableUsers = false;
   users.users.jeremie = {
-    isNormalUser = true;
-    createHome = true;
-    home = "/home/jeremie";
-    extraGroups = [ "wheel" ];
     # Hash du mot de passe stocké de manière sécurisée dans sops
     # Le fichier de secrets est chiffré et ne peut être déchiffré que par l'hôte
     hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
   };
-
-  # Root sans mot de passe (SSH root déjà interdit)
-  users.users.root.password = null;
-
-  # Sudo - Permet au groupe wheel d'exécuter toutes les commandes sans mot de passe
-  security.sudo.enable = true;
-  security.sudo.wheelNeedsPassword = false;
-
-  # QEMU Guest Agent
-  services.qemuGuest.enable = true;
 
   services.tailscale = {
     enable = true;
@@ -91,20 +39,4 @@
     };
   };
 
-  # Fish activé au niveau système (requis pour users.users.jeremie.shell)
-  # La configuration Fish détaillée est gérée par Home Manager
-  programs.fish.enable = true;
-
-  # ZSH - Commenté (remplacé par Fish)
-  # programs.zsh.enable = true;
-
-  # Tmux au niveau système
-  programs.tmux.enable = true;
-
-  # Shell par défaut pour l'utilisateur jeremie
-  users.users.jeremie.shell = pkgs.fish;
-
-  # Paquets système essentiels
-  # Note: git est maintenant géré par modules/git.nix (importé via base.nix)
-  environment.systemPackages = with pkgs; [ curl wget ];
 }

--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -1,79 +1,25 @@
 { config, pkgs, ... }:
 
 {
- imports = [
+  imports = [
     ./hardware-configuration.nix
     ../../modules/tailscale.nix  # <--- AJOUTE ÇA
     # ... tes autres imports
   ];
 
-  # Boot
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-
-  # Console série pour VM Proxmox
-  boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty1" ];
-  console.earlySetup = true;
-
   # Système
-  time.timeZone = "Europe/Paris";
   system.stateVersion = "24.05";
-
-  # Activer les flakes et nix-command
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   # Réseau
   networking.hostName = "mimosa";  # Serveur web
   networking.useDHCP = true;
-  # Firewall : SSH + Tailscale + Web (ports gérés par j12z-webserver)
-  networking.firewall = {
-    enable = true;
-    allowedTCPPorts = [ 22 ];  # SSH
-    # Les autres ports (80, 443) seront ouverts par j12z-webserver
-  };
-
-  # SSH
-  services.openssh.enable = true;
-  services.openssh.settings = {
-    PasswordAuthentication = false;
-    KbdInteractiveAuthentication = false;
-    PubkeyAuthentication = true;
-    PermitRootLogin = "no";
-  };
-
-  # Configuration SSH pour l'utilisateur jeremie
-  services.openssh.authorizedKeysFiles = [
-    "/etc/ssh/authorized_keys.d/%u"
-    "~/.ssh/authorized_keys"
-  ];
-
-  environment.etc."ssh/authorized_keys.d/jeremie" = {
-    text = ''
-      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac
-    '';
-    mode = "0644";
-  };
 
   # Utilisateur
   users.users.jeremie = {
-    isNormalUser = true;
-    createHome = true;
-    home = "/home/jeremie";
-    extraGroups = [ "wheel" ];
     # Hash du mot de passe stocké de manière sécurisée dans sops
     # Le fichier de secrets est chiffré et ne peut être déchiffré que par l'hôte
     hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
   };
-
-  # Root sans mot de passe (SSH root déjà interdit)
-  users.users.root.password = null;
-
-  # Sudo sans mot de passe pour le groupe wheel (sécurisé car SSH par clé uniquement)
-  security.sudo.enable = true;
-  security.sudo.wheelNeedsPassword = false;
-
-  # QEMU Guest Agent pour Proxmox
-  services.qemuGuest.enable = true;
 
   # Configuration sops-nix pour la gestion des secrets
   sops = {
@@ -107,17 +53,4 @@
     openFirewall = false;
   };
 
-  # Fish activé au niveau système (requis pour users.users.jeremie.shell)
-  # La configuration Fish détaillée est gérée par Home Manager
-  programs.fish.enable = true;
-
-  # Shell par défaut pour l'utilisateur jeremie
-  users.users.jeremie.shell = pkgs.fish;
-
-  # Paquets système essentiels
-  # Note: git est maintenant géré par modules/git.nix (importé via base.nix)
-  environment.systemPackages = with pkgs; [
-    curl
-    wget
-  ];
 }

--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -9,74 +9,17 @@
 
   ];
 
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-
-  # Console série Proxmox
-  boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty1" ];
-  console.earlySetup = true;
-
-  time.timeZone = "Europe/Paris";
   system.stateVersion = "25.05";
-
-  # Activer les flakes et nix-command
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   # Réseau
   networking.hostName = "whitelily";  # VM n8n automation
   networking.useDHCP = true;
   # Configuration DNS (resolvconf désactivé, donc configuration manuelle)
   networking.nameservers = [ "8.8.8.8" "1.1.1.1" ];
-  # Firewall activé (Cloudflare Tunnel = trafic sortant uniquement)
-  networking.firewall = {
-    enable = true;
-    allowedTCPPorts = [ 22 ]; # SSH uniquement (Cloudflare Tunnel = trafic sortant)
-  };
-
-  # SSH
-  services.openssh.enable = true;
-  services.openssh.settings = {
-    PasswordAuthentication = false;
-    KbdInteractiveAuthentication = false;
-    PubkeyAuthentication = true;
-    PermitRootLogin = "no";
-  };
-
-  services.openssh.authorizedKeysFiles = [
-    "/etc/ssh/authorized_keys.d/%u"
-    "~/.ssh/authorized_keys"
-  ];
-
-  # Clés SSH autorisées
-  environment.etc."ssh/authorized_keys.d/jeremie" = {
-    text = ''
-      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKmKLrSci3dXG3uHdfhGXCgOXj/ZP2wwQGi36mkbH/YM jeremie@mac
-    '';
-    mode = "0644";
-  };
-
-  users.mutableUsers = false;
-
-  # Utilisateur jeremie
   users.users.jeremie = {
-    isNormalUser = true;
-    createHome = true;
-    home = "/home/jeremie";
-    extraGroups = [ "wheel" ];
     # Hash du mot de passe stocké de manière sécurisée dans sops
     hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
-    shell = pkgs.fish;
   };
-
-  # Root sans mot de passe (SSH root déjà interdit)
-  users.users.root.password = null;
-
-  # Sudo - Permet au groupe wheel d'exécuter toutes les commandes sans mot de passe
-  security.sudo.enable = true;
-  security.sudo.wheelNeedsPassword = false;
-
-  # QEMU Guest Agent
-  services.qemuGuest.enable = true;
 
   services.tailscale = {
     enable = true;
@@ -149,21 +92,9 @@
     retentionGdrive = 30;
   };
 
-  # Fish activé au niveau système (requis pour users.users.jeremie.shell)
-  # La configuration Fish détaillée est gérée par Home Manager
-  programs.fish.enable = true;
-
-  # ZSH - Commenté (remplacé par Fish)
-  # programs.zsh.enable = true;
-
-  # Tmux au niveau système
-  programs.tmux.enable = true;
-
   # Paquets système essentiels
   # Note: git est maintenant géré par modules/git.nix (importé via base.nix)
   environment.systemPackages = with pkgs; [
-    curl
-    wget
     htop
     restic  # Pour les backups
     gzip

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -2,10 +2,8 @@
 # Module commun "base.nix"
 # ---------------------------------------------------------------------------
 # Ce module est chargé sur toutes les machines virtuelles définies dans ce
-# dépôt. Il regroupe les paquets système de base qui doivent être présents
-# partout pour l'administration et le débogage. Actuellement, il assure
-# l'installation de `jq` et de `git`, ainsi que la gestion déclarative des
-# permissions du dépôt nix-config.
+# dépôt. Il regroupe les paquets et options de base qui doivent être présents
+# partout pour l'administration et le débogage.
 # ============================================================================
 
 { pkgs, ... }:
@@ -14,5 +12,18 @@
     ./git.nix
   ];
 
-  environment.systemPackages = [ pkgs.jq ];
+  time.timeZone = "Europe/Paris";
+
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
+  programs = {
+    fish.enable = true;
+    tmux.enable = true;
+  };
+
+  environment.systemPackages = with pkgs; [
+    curl
+    wget
+    jq
+  ];
 }


### PR DESCRIPTION
## Summary
- extend the base module with shared shell, tmux, package, and Nix defaults used across hosts
- introduce a new ssh module for common boot, SSH, sudo, and access configuration and import it for each host
- simplify individual host configurations to only carry host-specific networking, secrets, and user password settings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920740258c8832fbd7f4e4e86d91ef6)