### PR TITLE
Add reusable SOPS module for jeremie password hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,10 @@
         # Magnolia - Infrastructure Proxmox
         magnolia = nixpkgs.lib.nixosSystem {
           inherit system;
+          specialArgs = { defaultSopsFile = ./secrets/magnolia.yaml; };
           modules = [
             ./modules/base.nix
+            ./modules/sops.nix
             ./hosts/magnolia/configuration.nix
             sops-nix.nixosModules.sops
             home-manager.nixosModules.home-manager
@@ -42,8 +44,10 @@
         # Utilisé par le script d'installation pour éviter les problèmes réseau
         mimosa-minimal = nixpkgs.lib.nixosSystem {
           inherit system;
+          specialArgs = { defaultSopsFile = ./secrets/mimosa.yaml; };
           modules = [
             ./modules/base.nix
+            ./modules/sops.nix
             ./hosts/mimosa/configuration.nix
             sops-nix.nixosModules.sops
             home-manager.nixosModules.home-manager
@@ -60,8 +64,10 @@
         # Mimosa - Serveur web complet (configuration de production)
         mimosa = nixpkgs.lib.nixosSystem {
           inherit system;
+          specialArgs = { defaultSopsFile = ./secrets/mimosa.yaml; };
           modules = [
             ./modules/base.nix
+            ./modules/sops.nix
             ./hosts/mimosa/configuration.nix
             ./hosts/mimosa/webserver.nix  # Configuration du serveur web
             j12z-site.nixosModules.j12z-webserver
@@ -78,8 +84,10 @@
         # Whitelily - VM n8n automation
         whitelily = nixpkgs.lib.nixosSystem {
           inherit system;
+          specialArgs = { defaultSopsFile = ./secrets/whitelily.yaml; };
           modules = [
             ./modules/base.nix
+            ./modules/sops.nix
             ./hosts/whitelily/configuration.nix
             sops-nix.nixosModules.sops
             home-manager.nixosModules.home-manager
@@ -94,8 +102,10 @@
         # Demo - VM de démonstration minimale
         demo = nixpkgs.lib.nixosSystem {
           inherit system;
+          specialArgs = { defaultSopsFile = ./secrets/common.yaml; };
           modules = [
             ./modules/base.nix
+            ./modules/sops.nix
             ./hosts/demo/configuration.nix
             sops-nix.nixosModules.sops
           ];

--- a/hosts/demo/configuration.nix
+++ b/hosts/demo/configuration.nix
@@ -4,6 +4,7 @@
 {
   imports = [
     ./hardware-configuration.nix
+    ../../modules/sops.nix
     ../../modules/tailscale.nix
   ];
 
@@ -67,6 +68,9 @@
   security.sudo.enable = true;
   security.sudo.wheelNeedsPassword = false;
 
+  # Ne pas gérer de hash de mot de passe via sops sur cette VM de démo
+  jeremiePasswordHash.enable = false;
+
   # QEMU Guest Agent
   services.qemuGuest.enable = true;
 
@@ -74,12 +78,6 @@
     enable = true;
     useRoutingFeatures = "none";
     openFirewall = false;
-  };
-
-  # Configuration sops-nix pour la gestion des secrets communs (Tailscale)
-  sops = {
-    defaultSopsFile = ../../secrets/common.yaml;
-    age.keyFile = "/var/lib/sops-nix/key.txt";
   };
 
   # Fish activé au niveau système (requis pour users.users.jeremie.shell)

--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./hardware-configuration.nix
+    ../../modules/sops.nix
     ../../modules/tailscale.nix
   ];
 
@@ -56,9 +57,6 @@
     createHome = true;
     home = "/home/jeremie";
     extraGroups = [ "wheel" ];
-    # Hash du mot de passe stocké de manière sécurisée dans sops
-    # Le fichier de secrets est chiffré et ne peut être déchiffré que par l'hôte
-    hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
   };
 
   # Root sans mot de passe (SSH root déjà interdit)
@@ -75,20 +73,6 @@
     enable = true;
     useRoutingFeatures = "none";
     openFirewall = false;
-  };
-
-  # Configuration sops-nix pour la gestion des secrets
-  sops = {
-    defaultSopsFile = ../../secrets/magnolia.yaml;
-    age = {
-      keyFile = "/var/lib/sops-nix/key.txt";
-    };
-    secrets = {
-      # Hash du mot de passe de l'utilisateur jeremie
-      jeremie-password-hash = {
-        neededForUsers = true;
-      };
-    };
   };
 
   # Fish activé au niveau système (requis pour users.users.jeremie.shell)

--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -1,8 +1,9 @@
 { config, pkgs, ... }:
 
 {
- imports = [
+  imports = [
     ./hardware-configuration.nix
+    ../../modules/sops.nix
     ../../modules/tailscale.nix  # <--- AJOUTE ÇA
     # ... tes autres imports
   ];
@@ -60,9 +61,6 @@
     createHome = true;
     home = "/home/jeremie";
     extraGroups = [ "wheel" ];
-    # Hash du mot de passe stocké de manière sécurisée dans sops
-    # Le fichier de secrets est chiffré et ne peut être déchiffré que par l'hôte
-    hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
   };
 
   # Root sans mot de passe (SSH root déjà interdit)
@@ -74,22 +72,6 @@
 
   # QEMU Guest Agent pour Proxmox
   services.qemuGuest.enable = true;
-
-  # Configuration sops-nix pour la gestion des secrets
-  sops = {
-    defaultSopsFile = ../../secrets/mimosa.yaml;
-    age = {
-      keyFile = "/var/lib/sops-nix/key.txt";
-    };
-    secrets = {
-      # Hash du mot de passe de l'utilisateur jeremie
-      jeremie-password-hash = {
-        neededForUsers = true;
-      };
-      # Note: Le secret cloudflare-tunnel-token est défini dans webserver.nix
-      # qui est importé uniquement dans la configuration "mimosa" complète
-    };
-  };
 
   # Configuration du site j12zdotcom
   # La configuration du serveur web est dans ./webserver.nix

--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -5,6 +5,7 @@
     ./hardware-configuration.nix
     ./n8n.nix
     ./n8n-backup.nix
+    ../../modules/sops.nix
     ../../modules/tailscale.nix
 
   ];
@@ -63,8 +64,6 @@
     createHome = true;
     home = "/home/jeremie";
     extraGroups = [ "wheel" ];
-    # Hash du mot de passe stocké de manière sécurisée dans sops
-    hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
     shell = pkgs.fish;
   };
 
@@ -86,7 +85,6 @@
 
   # Configuration sops-nix pour la gestion des secrets
   sops = {
-    defaultSopsFile = ../../secrets/whitelily.yaml;
     age = {
       # Utiliser UNIQUEMENT la clé age partagée (copiée depuis le Mac)
       keyFile = "/var/lib/sops-nix/key.txt";
@@ -94,10 +92,6 @@
       sshKeyPaths = [];
     };
     secrets = {
-      # Hash du mot de passe de l'utilisateur jeremie
-      jeremie-password-hash = {
-        neededForUsers = true;
-      };
       # Secrets n8n (utilisés dans n8n.nix)
       "n8n/encryption_key" = { owner = "root"; group = "root"; mode = "0400"; };
       "n8n/basic_user" = { owner = "root"; group = "root"; mode = "0400"; };

--- a/modules/sops.nix
+++ b/modules/sops.nix
@@ -1,0 +1,24 @@
+{ config, lib, defaultSopsFile, ... }:
+
+let
+  inherit (lib) mkDefault mkEnableOption mkIf;
+  cfg = config.jeremiePasswordHash;
+in {
+  options.jeremiePasswordHash = {
+    enable = mkEnableOption ''Gestion du hash de mot de passe de l'utilisateur "jeremie" via sops'' // { default = true; };
+  };
+
+  config = {
+    sops = {
+      inherit defaultSopsFile;
+      age.keyFile = mkDefault "/var/lib/sops-nix/key.txt";
+    };
+  } // mkIf cfg.enable {
+    # Active uniquement si le hash de mot de passe est géré via sops pour cet hôte
+    # (permet de conserver les configurations sans mot de passe comme hosts/demo)
+    sops.secrets.jeremie-password-hash.neededForUsers = true;
+
+    users.users.jeremie.hashedPasswordFile =
+      config.sops.secrets.jeremie-password-hash.path;
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared sops module that sets jeremie’s password hash through secrets and allows opting out per host
- wire each host configuration to import the new module and feed its host-specific sops file via specialArgs
- clean up host files so only the shared module sets the hashed password while preserving existing sops secrets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69207401634c832f9e5304942a783ffa)