### PR TITLE
Add shared SOPS module for jeremie password secrets

### DIFF
--- a/hosts/demo/configuration.nix
+++ b/hosts/demo/configuration.nix
@@ -4,6 +4,7 @@
 {
   imports = [
     ./hardware-configuration.nix
+    (import ../../modules/sops.nix { defaultSopsFile = ../../secrets/common.yaml; })
     ../../modules/tailscale.nix
   ];
 
@@ -14,20 +15,9 @@
   networking.useDHCP = true;
   networking.resolvconf.enable = false;
 
-  # Utilisateur jeremie (pas de mot de passe, SSH uniquement)
-  users.users.jeremie = {
-    password = null;
-  };
-
   services.tailscale = {
     enable = true;
     useRoutingFeatures = "none";
     openFirewall = false;
-  };
-
-  # Configuration sops-nix pour la gestion des secrets communs (Tailscale)
-  sops = {
-    defaultSopsFile = ../../secrets/common.yaml;
-    age.keyFile = "/var/lib/sops-nix/key.txt";
   };
 }

--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./hardware-configuration.nix
+    (import ../../modules/sops.nix { defaultSopsFile = ../../secrets/magnolia.yaml; })
     ../../modules/tailscale.nix
   ];
 
@@ -13,30 +14,9 @@
   networking.useDHCP = true;
   # Désactiver resolvconf (DHCP gère déjà le DNS)
   networking.resolvconf.enable = false;
-  users.users.jeremie = {
-    # Hash du mot de passe stocké de manière sécurisée dans sops
-    # Le fichier de secrets est chiffré et ne peut être déchiffré que par l'hôte
-    hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
-  };
-
   services.tailscale = {
     enable = true;
     useRoutingFeatures = "none";
     openFirewall = false;
   };
-
-  # Configuration sops-nix pour la gestion des secrets
-  sops = {
-    defaultSopsFile = ../../secrets/magnolia.yaml;
-    age = {
-      keyFile = "/var/lib/sops-nix/key.txt";
-    };
-    secrets = {
-      # Hash du mot de passe de l'utilisateur jeremie
-      jeremie-password-hash = {
-        neededForUsers = true;
-      };
-    };
-  };
-
 }

--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./hardware-configuration.nix
+    (import ../../modules/sops.nix { defaultSopsFile = ../../secrets/mimosa.yaml; })
     ../../modules/tailscale.nix  # <--- AJOUTE ÇA
     # ... tes autres imports
   ];
@@ -14,24 +15,9 @@
   networking.hostName = "mimosa";  # Serveur web
   networking.useDHCP = true;
 
-  # Utilisateur
-  users.users.jeremie = {
-    # Hash du mot de passe stocké de manière sécurisée dans sops
-    # Le fichier de secrets est chiffré et ne peut être déchiffré que par l'hôte
-    hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
-  };
-
   # Configuration sops-nix pour la gestion des secrets
   sops = {
-    defaultSopsFile = ../../secrets/mimosa.yaml;
-    age = {
-      keyFile = "/var/lib/sops-nix/key.txt";
-    };
     secrets = {
-      # Hash du mot de passe de l'utilisateur jeremie
-      jeremie-password-hash = {
-        neededForUsers = true;
-      };
       # Note: Le secret cloudflare-tunnel-token est défini dans webserver.nix
       # qui est importé uniquement dans la configuration "mimosa" complète
     };

--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -5,6 +5,7 @@
     ./hardware-configuration.nix
     ./n8n.nix
     ./n8n-backup.nix
+    (import ../../modules/sops.nix { defaultSopsFile = ../../secrets/whitelily.yaml; })
     ../../modules/tailscale.nix
 
   ];
@@ -16,11 +17,6 @@
   networking.useDHCP = true;
   # Configuration DNS (resolvconf désactivé, donc configuration manuelle)
   networking.nameservers = [ "8.8.8.8" "1.1.1.1" ];
-  users.users.jeremie = {
-    # Hash du mot de passe stocké de manière sécurisée dans sops
-    hashedPasswordFile = config.sops.secrets.jeremie-password-hash.path;
-  };
-
   services.tailscale = {
     enable = true;
     useRoutingFeatures = "none";
@@ -29,7 +25,6 @@
 
   # Configuration sops-nix pour la gestion des secrets
   sops = {
-    defaultSopsFile = ../../secrets/whitelily.yaml;
     age = {
       # Utiliser UNIQUEMENT la clé age partagée (copiée depuis le Mac)
       keyFile = "/var/lib/sops-nix/key.txt";
@@ -37,10 +32,6 @@
       sshKeyPaths = [];
     };
     secrets = {
-      # Hash du mot de passe de l'utilisateur jeremie
-      jeremie-password-hash = {
-        neededForUsers = true;
-      };
       # Secrets n8n (utilisés dans n8n.nix)
       "n8n/encryption_key" = { owner = "root"; group = "root"; mode = "0400"; };
       "n8n/basic_user" = { owner = "root"; group = "root"; mode = "0400"; };

--- a/modules/sops.nix
+++ b/modules/sops.nix
@@ -1,0 +1,28 @@
+# ============================================================================
+# Module commun "sops.nix"
+# ---------------------------------------------------------------------------
+# Configure la gestion des secrets avec sops-nix et centralise le secret
+# contenant le hash du mot de passe de l'utilisateur "jeremie".
+# ============================================================================
+
+{ defaultSopsFile }:
+{ config, lib, ... }:
+let
+  inherit (lib) mkDefault;
+in {
+  # Fichier de secrets utilisé par défaut pour l'hôte (fourni via l'import).
+  sops.defaultSopsFile = defaultSopsFile;
+
+  # Chemin de la clé age par défaut (modifiable par les hôtes si nécessaire).
+  sops.age.keyFile = mkDefault "/var/lib/sops-nix/key.txt";
+
+  # Secret stockant le hash du mot de passe de l'utilisateur jeremie.
+  sops.secrets.jeremie-password-hash = {
+    neededForUsers = true;
+  };
+
+  # L'utilisateur jeremie est défini dans modules/ssh.nix ; ici on ne fait
+  # qu'attacher le hash du mot de passe déchiffré par sops-nix.
+  users.users.jeremie.hashedPasswordFile =
+    mkDefault config.sops.secrets.jeremie-password-hash.path;
+}


### PR DESCRIPTION
## Summary
- add a reusable sops module parameterized by each host's `defaultSopsFile` for the `jeremie-password-hash` secret
- import the new module in all host configurations and remove duplicate user password definitions
- keep host-specific secrets (e.g., tailscale, n8n) intact while aligning with the shared ssh user configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69207811e2f8832f8ec8205701d47a43)