### PR TITLE
Fix tailscale auto reconnect check

### DIFF
--- a/modules/tailscale.nix
+++ b/modules/tailscale.nix
@@ -16,10 +16,12 @@ let
 
     # === VÉRIFICATION : Est-on déjà connecté ? ===
     log "🔍 Vérification de l'état actuel de Tailscale"
-    if ${pkgs.tailscale}/bin/tailscale status --json 2>/dev/null | ${pkgs.jq}/bin/jq -e '.BackendState == "Running"' > /dev/null; then
+    if ${pkgs.tailscale}/bin/tailscale status --json 2>/dev/null | ${pkgs.jq}/bin/jq -e '.BackendState == "Running" and .Self.Online == true' > /dev/null; then
       log "✅ Déjà connecté à Tailscale"
       exit 0  # On quitte proprement, pas d'erreur
     fi
+
+    log "ℹ️  Déconnexion détectée, tentative de reconnexion"
 
     # === RÉCUPÉRATION D'UN ACCESS TOKEN OAUTH ===
     log "🔑 Demande d'un access token OAuth (grant_type=client_credentials)"


### PR DESCRIPTION
## Summary
- ensure tailscale auth script only exits when backend is running and online
- log when reconnection is attempted after detecting logout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69207d292ca8832f904ccb07c54256b1)