### PR TITLE
Setup SSH forwarding for GitHub pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,24 @@ sudo nixos-rebuild switch --flake .#demo            # VM de démonstration
 
 **Note** : Pour whitelily, consultez le guide complet [docs/WHITELILY-N8N-SETUP.md](docs/WHITELILY-N8N-SETUP.md) qui détaille la configuration des secrets SOPS et du Cloudflare Tunnel.
 
+## 🔑 Push GitHub depuis magnolia
+
+Pour pusher sur GitHub depuis magnolia en utilisant les clés SSH de ton Mac :
+
+**1. Config SSH sur ton Mac** (`~/.ssh/config`) :
+```
+Host magnolia
+    ForwardAgent yes
+    IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+```
+
+**2. Connecte-toi** :
+```bash
+ssh magnolia  # L'agent SSH est automatiquement forwardé
+```
+
+**3. C'est tout !** Git sur magnolia est configuré pour utiliser SSH automatiquement.
+
 ## 📁 Structure du repository
 
 ```

--- a/home/jeremie.nix
+++ b/home/jeremie.nix
@@ -79,13 +79,19 @@
     '';
   };
 
-  # Git - Configuration pour mimosa uniquement
+  # Git - Configuration globale
   programs.git = {
-    enable = osConfig.networking.hostName == "mimosa";
+    enable = true;
     userName = "JeremieAlcaraz";
     userEmail = "hello@jeremiealcaraz.com";
     extraConfig = {
       safe.directory = "/etc/nixos";
-    };
+    } // (if osConfig.networking.hostName == "magnolia" then {
+      # Réécrire automatiquement les URLs HTTPS en SSH pour GitHub (magnolia uniquement)
+      url."git@github.com:".insteadOf = [
+        "https://github.com/"
+        "http://local_proxy@127.0.0.1:16900/git/"
+      ];
+    } else {});
   };
 }

--- a/modules/ssh.nix
+++ b/modules/ssh.nix
@@ -27,6 +27,8 @@
       KbdInteractiveAuthentication = false;
       PubkeyAuthentication = true;
       PermitRootLogin = "no";
+      # Permet le forwarding de l'agent SSH pour utiliser les clés du client
+      AllowAgentForwarding = true;
     };
     authorizedKeysFiles = [
       "/etc/ssh/authorized_keys.d/%u"


### PR DESCRIPTION
Configuration déclarative pour permettre git push depuis les hôtes NixOS en utilisant les clés SSH du Mac via 1Password agent.

Changements :
- modules/ssh.nix : AllowAgentForwarding = true
- home/jeremie.nix : Réécriture automatique des URLs Git vers SSH
- README.md : Section concise (3 étapes)

Tout est déclaratif, aucun script nécessaire.