### PR TITLE
Fix n8n image reference - remove invalid null digest

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -175,7 +175,7 @@ EOF
   virtualisation.oci-containers = {
     backend = "podman";
     containers.n8n = {
-      image = "docker.io/n8nio/n8n:next@sha256:null";  # Tag next pour les dernières betas
+      image = "docker.io/n8nio/n8n:next";  # Tag next pour les dernières betas
       autoStart = true;
       # Pas de ports mapping avec --network host (le conteneur utilise directement les ports de l'hôte)
 


### PR DESCRIPTION
The previous PR incorrectly set the image to "next@sha256:null" which caused podman to fail with "invalid reference format".

Reverting to simple "next" tag to use the latest n8n beta without a pinned digest. The workflow will create PRs with proper digests once the N8N_UPDATE_TOKEN secret is configured.

Fixes podman-n8n.service startup failure.