### PR TITLE
Update n8n to latest version with proper digest

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -175,7 +175,7 @@ EOF
   virtualisation.oci-containers = {
     backend = "podman";
     containers.n8n = {
-      image = "docker.io/n8nio/n8n:next";  # Tag next pour les dernières betas
+      image = "docker.io/n8nio/n8n:next@sha256:50f1b188e0398c409eab52a530cac79c5b477d1d30e8e972ed73935e5eaeacfd";  # Tag next pour les dernières betas
       autoStart = true;
       # Pas de ports mapping avec --network host (le conteneur utilise directement les ports de l'hôte)
 


### PR DESCRIPTION
Add the current n8n:next digest (sha256:50f1b188...) to ensure reproducible builds and enable automatic updates via the workflow.

With the N8N_UPDATE_TOKEN secret now configured, the workflow will automatically create PRs when new versions are available.