### PR TITLE
Configure follower node to consume configuration only

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -284,11 +284,30 @@ git push
 
 ### Depuis la VM (déploiement)
 
+**Pour les nœuds follower (whitelily, mimosa, etc.)** :
+
 ```bash
 # 1. Se connecter à la VM
 ssh jeremie@<IP_DE_LA_VM>
 
-# 2. Pull les changements
+# 2. Mise à jour forcée (écrase les modifications locales)
+cd /etc/nixos
+gu  # Alias pour: git fetch --all; and git reset --hard origin/main
+
+# 3. Tester la config avant de l'appliquer (optionnel)
+sudo nixos-rebuild test --flake .#<hostname>
+
+# 4. Appliquer définitivement
+sudo nixos-rebuild switch --flake .#<hostname>
+```
+
+**Pour le nœud de développement (magnolia uniquement)** :
+
+```bash
+# 1. Se connecter à la VM
+ssh jeremie@<IP_DE_LA_VM>
+
+# 2. Pull les changements (avec gestion des conflits)
 cd /etc/nixos
 git pull
 
@@ -820,7 +839,18 @@ sudo reboot
 
 **Cause** : Modifications locales ou branche différente.
 
-**Solution** :
+**Solution pour nœuds follower (whitelily, etc.)** :
+
+Les nœuds follower ne doivent jamais modifier la configuration localement. Utilisez la mise à jour forcée :
+
+```bash
+cd /etc/nixos
+gu  # Alias pour: git fetch --all; and git reset --hard origin/main
+```
+
+Cela écrase toutes les modifications locales et synchronise avec le serveur, sans jamais demander de résoudre des conflits.
+
+**Solution pour développement (magnolia uniquement)** :
 ```bash
 cd /etc/nixos
 git status

--- a/modules/aliases.nix
+++ b/modules/aliases.nix
@@ -74,6 +74,9 @@
       gl = "git log --oneline --graph --decorate -10";
       gla = "git log --oneline --graph --decorate --all -20";
 
+      # Mise à jour forcée pour nœuds follower (écrase les modifications locales)
+      gu = "git fetch --all; and git reset --hard origin/main";
+
       # ═══════════════════════════════════════════════════
       # 🛠️ SYSTEMD - Gestion des services
       # ═══════════════════════════════════════════════════


### PR DESCRIPTION
Adds a new Fish shell alias 'gu' that performs a forced git update by fetching all changes and hard resetting to origin/main. This is designed for follower nodes (whitelily, mimosa, etc.) that should never have local modifications and need to always sync exactly with the main branch without conflict resolution.

Changes:
- modules/aliases.nix: Add 'gu' alias for forced git updates
- docs/DEPLOYMENT.md: Document follower node update strategy and 'gu' usage

The 'gu' alias executes: git fetch --all; and git reset --hard origin/main This eliminates the need for manual stash/pull/pop workflows on follower nodes.