### PR TITLE
Update Nix Darwin configuration and lock file

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     darwin = {
-      url = "github:lnl7/nix-darwin/master";
+      url = "github:lnl7/nix-darwin/nix-darwin-24.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
Fixes version mismatch between nix-darwin (was 25.11 from master) and nixpkgs (24.11). The nix-darwin and Nixpkgs branches must match for proper compatibility.