### PR TITLE
Fix code comments

### DIFF
--- a/hosts/marigold/configuration.nix
+++ b/hosts/marigold/configuration.nix
@@ -1,1 +1,7 @@
-{ }
+{ config, pkgs, ... }:
+
+{
+  # Used for backwards compatibility, please read the changelog before changing.
+  # $ darwin-rebuild changelog
+  system.stateVersion = 5;
+}


### PR DESCRIPTION
The nix-darwin configuration for marigold was missing the required system.stateVersion option, causing build failures. Added stateVersion 5 as recommended by nix-darwin for new installations.