### PR TITLE
Fix Nix build environment setup error

### DIFF
--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -11,6 +11,11 @@
   # Système
   system.stateVersion = "24.05";
 
+  # Packages système requis pour les builds Nix
+  environment.systemPackages = with pkgs; [
+    cacert  # Certificats CA requis pour pnpm.fetchDeps et autres FODs
+  ];
+
   # Réseau
   networking.hostName = "mimosa";  # Serveur web
   networking.useDHCP = true;
@@ -30,14 +35,11 @@
   # les téléchargements npm pendant l'installation initiale
   # Note: mimosa.webserver.enable est activé dans flake.nix pour la config "mimosa"
 
-  # Nix build settings - Permettre aux fixed-output derivations d'accéder au DNS
-  # Nécessaire pour pnpm.fetchDeps dans le flake j12zdotcom
+  # Nix build settings
   nix.settings = {
     sandbox = true;  # Garder la sandbox activée (sécurité)
-    extra-sandbox-paths = [
-      "/etc/resolv.conf"  # Accès DNS pour fetcher les dépendances npm
-      "/etc/ssl/certs"    # Certificats SSL pour https://registry.npmjs.org
-    ];
+    # Note: Les Fixed Output Derivations (FOD) comme pnpm.fetchDeps ont accès au réseau
+    # Les certificats SSL viennent de cacert dans systemPackages et nativeBuildInputs de fetchDeps
   };
 
   # Tailscale


### PR DESCRIPTION
Fixes 'Permission denied' error when accessing ca-certificates.crt during pnpm.fetchDeps execution. The issue occurs because Fixed Output Derivations (FOD) in the Nix sandbox need access to CA certificates to validate HTTPS connections to the npm registry.

Changes:
- Add cacert to environment.systemPackages to ensure CA certificates are available
- Simplify nix.settings.sandbox configuration - extra-sandbox-paths doesn't work for FODs
- Add comments explaining how SSL certificates work in FODs

This works in combination with the nativeBuildInputs = [ pkgs.cacert ] in the j12zdotcom flake.nix fetchDeps configuration.