### PR TITLE
fix(mimosa): configure system-wide SSL certificate file for Nix FODs

### DIFF
--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -38,8 +38,9 @@
   # Nix build settings
   nix.settings = {
     sandbox = true;  # Garder la sandbox activée (sécurité)
-    # Note: Les Fixed Output Derivations (FOD) comme pnpm.fetchDeps ont accès au réseau
-    # Les certificats SSL viennent de cacert dans systemPackages et nativeBuildInputs de fetchDeps
+    # Certificats SSL pour toutes les Fixed Output Derivations (FOD)
+    # Permet à pnpm.fetchDeps et autres FOD de valider les connexions HTTPS
+    ssl-cert-file = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
   };
 
   # Tailscale


### PR DESCRIPTION
Add nix.settings.ssl-cert-file to point to cacert bundle. This configures SSL certificates globally for all Fixed Output Derivations (FOD) including pnpm.fetchDeps, allowing them to validate HTTPS connections in the sandbox.

This is the correct way to configure SSL for FODs - the certificates must be configured at the Nix daemon level, not just in individual derivations.