### PR TITLE
feat(mimosa): enable automatic Nix build for j12zdotcom site

### DIFF
--- a/hosts/mimosa/webserver.nix
+++ b/hosts/mimosa/webserver.nix
@@ -16,9 +16,8 @@ in
       enable = true;
       domain = "jeremiealcaraz.com";
       email = "hello@jeremiealcaraz.com";
-      # TEMPORAIRE: Utiliser un dossier local au lieu du build Nix
-      # TODO: Remettre le build Nix automatique une fois le problème sandbox résolu
-      siteRoot = /var/www/j12zdotcom;
+      # Build Nix automatique activé (le problème SSL est résolu !)
+      # siteRoot utilise la valeur par défaut du module: le build Nix du site
       # Cloudflare Tunnel activé avec sops
       enableCloudflaredTunnel = true;
       cloudflaredTokenFile = config.sops.secrets.cloudflare-tunnel-token.path;


### PR DESCRIPTION
Remove temporary siteRoot override that pointed to /var/www/j12zdotcom. Now that the SSL certificate issue is resolved (ssl-cert-file in nix.settings), the site can be built automatically by Nix from the j12z-site flake input.

This makes the deployment fully reproducible:
- Site builds automatically during nixos-rebuild
- No manual file copying needed
- Immutable result in /nix/store/
- Automatic updates when flake input is updated