### PR TITLE
fix(mimosa): add DNS access to Nix sandbox for FODs

### DIFF
--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -41,6 +41,8 @@
     # Certificats SSL pour toutes les Fixed Output Derivations (FOD)
     # Permet à pnpm.fetchDeps et autres FOD de valider les connexions HTTPS
     ssl-cert-file = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+    # Accès DNS pour les FOD (requis car mimosa utilise le DNS Tailscale)
+    extra-sandbox-paths = [ "/etc/resolv.conf" ];
   };
 
   # Tailscale


### PR DESCRIPTION
Add /etc/resolv.conf to extra-sandbox-paths to allow Fixed Output Derivations (FOD) like pnpm.fetchDeps to resolve domain names.

Issue: pnpm.fetchDeps was failing with "EAI_AGAIN" DNS errors when trying to download packages from registry.npmjs.org. This happened because:
- mimosa uses Tailscale's MagicDNS (100.100.100.100)
- The Nix sandbox didn't have access to /etc/resolv.conf
- FODs couldn't resolve domain names

Solution: Mount /etc/resolv.conf in the sandbox so FODs can access DNS.

Tested: Network connectivity works outside sandbox (ping, curl all OK).