### PR TITLE
fix(mimosa): add public DNS fallback for Nix FOD builds

### DIFF
--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -19,6 +19,10 @@
   # Réseau
   networking.hostName = "mimosa";  # Serveur web
   networking.useDHCP = true;
+  # DNS fallback pour les builds Nix (FOD)
+  # Tailscale MagicDNS (100.100.100.100) n'est pas accessible dans le sandbox
+  # Ajouter Google DNS comme fallback
+  networking.nameservers = [ "100.100.100.100" "8.8.8.8" "1.1.1.1" ];
 
   # Configuration sops-nix pour la gestion des secrets
   sops = {


### PR DESCRIPTION
Add Google DNS (8.8.8.8) and Cloudflare DNS (1.1.1.1) as fallback nameservers.

Issue: Tailscale MagicDNS (100.100.100.100) is not accessible from within the Nix sandbox for Fixed Output Derivations (FOD), causing EAI_AGAIN errors when pnpm.fetchDeps tries to download packages from registry.npmjs.org.

Solution: Configure public DNS servers as fallback in networking.nameservers. This allows FODs to resolve domain names even when Tailscale DNS is not accessible in the restricted sandbox environment.

Order: Tailscale first (for local resolution), then public DNS as fallback.