### PR TITLE
fix(scripts): use mimosa-minimal during installation

### DIFF
--- a/scripts/install-nixos.sh
+++ b/scripts/install-nixos.sh
@@ -324,8 +324,18 @@ step "Étape 7/7 : Installation de NixOS"
 
 cd /mnt/etc/nixos
 
+# Utiliser la config minimale pour mimosa lors de l'installation
+# (évite de builder j12zdotcom pendant l'installation)
+INSTALL_CONFIG="${HOST}"
+if [[ "${HOST}" == "mimosa" ]]; then
+    INSTALL_CONFIG="mimosa-minimal"
+    info "Installation de mimosa-minimal (sans serveur web)"
+    info "Après l'installation, vous pourrez activer le webserver avec:"
+    info "  sudo nixos-rebuild switch --flake .#mimosa"
+fi
+
 info "Installation en cours (cela peut prendre plusieurs minutes)..."
-nixos-install --flake ".#${HOST}" --no-root-passwd
+nixos-install --flake ".#${INSTALL_CONFIG}" --no-root-passwd
 
 # ========================================
 # Finalisation


### PR DESCRIPTION
Use mimosa-minimal configuration during nixos-install to avoid building j12zdotcom site (which requires network/npm) during the initial installation.

Problem: The install script was using .#mimosa directly, which includes the webserver and j12zdotcom site build. This causes:
- Network dependencies during installation (pnpm.fetchDeps)
- Longer installation time
- Potential failures if DNS/network issues

Solution: Install with .#mimosa-minimal first (no webserver), then user can activate the full configuration after installation with:
  sudo nixos-rebuild switch --flake .#mimosa

This follows the two-phase installation pattern documented in the flake.