### PR TITLE
refactor(mimosa): merge minimal and full configs with flag

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,27 +43,10 @@
           ];
         };
 
-        # Mimosa Minimal - Pour l'installation initiale (sans serveur web)
-        # Utilisé par le script d'installation pour éviter les problèmes réseau
-        mimosa-minimal = nixpkgs.lib.nixosSystem {
-          inherit system;
-          modules = [
-            ./modules/base.nix
-            ./modules/ssh.nix
-            ./hosts/mimosa/configuration.nix
-            sops-nix.nixosModules.sops
-            home-manager.nixosModules.home-manager
-            {
-              home-manager.useGlobalPkgs = true;
-              home-manager.useUserPackages = true;
-              home-manager.users.jeremie = import ./home/jeremie.nix;
-            }
-            # Le module j12z-webserver n'est PAS importé ici
-            # pour éviter les téléchargements npm pendant l'installation
-          ];
-        };
-
-        # Mimosa - Serveur web complet (configuration de production)
+        # Mimosa - Serveur web (webserver désactivé par défaut lors de l'installation)
+        # Pour activer le webserver après l'installation :
+        #   1. Éditez ce fichier et changez enable = false → enable = true
+        #   2. sudo nixos-rebuild switch --flake .#mimosa
         mimosa = nixpkgs.lib.nixosSystem {
           inherit system;
           modules = [
@@ -79,9 +62,10 @@
               home-manager.useUserPackages = true;
               home-manager.users.jeremie = import ./home/jeremie.nix;
             }
-            # Activer le webserver pour mimosa
+            # Webserver DÉSACTIVÉ par défaut (pour installation rapide)
+            # Changez "false" en "true" pour activer le site j12zdotcom
             {
-              mimosa.webserver.enable = true;
+              mimosa.webserver.enable = false;
             }
           ];
         };

--- a/scripts/install-nixos.sh
+++ b/scripts/install-nixos.sh
@@ -324,18 +324,17 @@ step "Étape 7/7 : Installation de NixOS"
 
 cd /mnt/etc/nixos
 
-# Utiliser la config minimale pour mimosa lors de l'installation
-# (évite de builder j12zdotcom pendant l'installation)
-INSTALL_CONFIG="${HOST}"
-if [[ "${HOST}" == "mimosa" ]]; then
-    INSTALL_CONFIG="mimosa-minimal"
-    info "Installation de mimosa-minimal (sans serveur web)"
-    info "Après l'installation, vous pourrez activer le webserver avec:"
-    info "  sudo nixos-rebuild switch --flake .#mimosa"
-fi
-
 info "Installation en cours (cela peut prendre plusieurs minutes)..."
-nixos-install --flake ".#${INSTALL_CONFIG}" --no-root-passwd
+nixos-install --flake ".#${HOST}" --no-root-passwd
+
+if [[ "${HOST}" == "mimosa" ]]; then
+    echo ""
+    info "ℹ️  Le webserver j12zdotcom est DÉSACTIVÉ par défaut"
+    info "Pour l'activer après l'installation :"
+    info "  1. Éditez /etc/nixos/flake.nix"
+    info "  2. Changez: mimosa.webserver.enable = false → true"
+    info "  3. sudo nixos-rebuild switch --flake .#mimosa"
+fi
 
 # ========================================
 # Finalisation


### PR DESCRIPTION
Replace separate mimosa-minimal and mimosa configs with a single mimosa configuration that has webserver disabled by default.

Benefits:
- Single hostname "mimosa" (no more confusion)
- Tailscale works correctly (same hostname)
- Installation is fast (webserver disabled by default)
- Simple activation: just change one flag in flake.nix

Changes:
- Removed: mimosa-minimal configuration
- Modified: mimosa now has mimosa.webserver.enable = false by default
- Updated: install script to use .#mimosa directly
- Added: instructions to enable webserver post-installation

To enable webserver after installation:
1. Edit /etc/nixos/flake.nix
2. Change: mimosa.webserver.enable = false → true
3. sudo nixos-rebuild switch --flake .#mimosa