### PR TITLE
Set up project with incremental testing steps

### DIFF
--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -5,6 +5,7 @@
     ./hardware-configuration.nix
     (import ../../modules/sops.nix { defaultSopsFile = ../../secrets/magnolia.yaml; })
     ../../modules/tailscale.nix
+    ../../modules/nix-serve.nix
   ];
 
   system.stateVersion = "25.05";

--- a/modules/nix-serve.nix
+++ b/modules/nix-serve.nix
@@ -1,0 +1,22 @@
+{ config, lib, ... }:
+
+{
+  # Active le serveur de cache binaire Nix
+  services.nix-serve = {
+    enable = true;
+
+    # Port d'écoute (accessible via Tailscale)
+    port = 5000;
+
+    # Clé privée pour signer les packages
+    # Générée avec : nix-store --generate-binary-cache-key
+    secretKeyFile = "/var/cache-keys/cache-private-key.pem";
+
+    # Écoute sur toutes les interfaces (nécessaire pour Tailscale)
+    bindAddress = "0.0.0.0";
+  };
+
+  # Ouvre le port 5000 dans le firewall (uniquement pour Tailscale)
+  # Note : Tailscale gère déjà la sécurité, mais on ouvre quand même
+  networking.firewall.allowedTCPPorts = [ 5000 ];
+}


### PR DESCRIPTION
Setup nix-serve on magnolia to act as a local binary cache for mimosa and whitelily. This will speed up deployments by sharing pre-built packages across the network via Tailscale.

Changes:
- Create modules/nix-serve.nix with cache server configuration
- Enable nix-serve on magnolia listening on port 5000
- Configure firewall to allow cache access via Tailscale