### PR TITLE
refactor(mimosa): use pre-built package from cache instead of rebuilding

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,12 +49,15 @@
         #   2. sudo nixos-rebuild switch --flake .#mimosa
         mimosa = nixpkgs.lib.nixosSystem {
           inherit system;
+          # Passer j12z-site en argument pour accéder au package pré-buildé
+          specialArgs = { inherit j12z-site; };
           modules = [
             ./modules/base.nix
             ./modules/ssh.nix
             ./hosts/mimosa/configuration.nix
             ./hosts/mimosa/webserver.nix  # Configuration du serveur web
-            j12z-site.nixosModules.j12z-webserver
+            # Retrait de j12z-site.nixosModules.j12z-webserver qui rebuild le site
+            # On utilise maintenant directement le package via specialArgs
             sops-nix.nixosModules.sops
             home-manager.nixosModules.home-manager
             {


### PR DESCRIPTION
Remove j12z-webserver module that rebuilds the site on every deploy. Now uses the pre-built package from j12z-site flake input, which will be downloaded from magnolia's cache instead of rebuilding from source.

Changes:
- Remove j12z-site.nixosModules.j12z-webserver from mimosa config
- Pass j12z-site as specialArgs to access packages directly
- Refactor webserver.nix to use j12z-site.packages.x86_64-linux.site
- Configure Caddy and Cloudflared services directly
- Simplify Cloudflared configuration using standard NixOS options

This eliminates the 1m+ rebuild time and npm dependency downloads, replacing it with a ~5 second cache download from magnolia via Tailscale.