### PR TITLE
fix(install): remove unsupported nixos-install flags

### DIFF
--- a/scripts/install-nixos.sh
+++ b/scripts/install-nixos.sh
@@ -334,7 +334,7 @@ cd /mnt/etc/nixos
 
 info "Installation en cours (cela peut prendre plusieurs minutes)..."
 info "Mode verbose activé pour voir les détails du téléchargement..."
-nixos-install --flake ".#${HOST}" --no-root-passwd -v -L --show-trace
+nixos-install --flake ".#${HOST}" --no-root-passwd -v
 
 if [[ "${HOST}" == "mimosa-bootstrap" ]]; then
     echo ""


### PR DESCRIPTION
Remove -L and --show-trace flags from nixos-install command as they are only supported by nix build, not nixos-install.

Keep only -v (verbose) flag which is supported by nixos-install.