### PR TITLE
feat: add GitHub Actions SSH keys declaratively

### DIFF
--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -6,6 +6,7 @@
     (import ../../modules/sops.nix { defaultSopsFile = ../../secrets/magnolia.yaml; })
     ../../modules/tailscale.nix
     ../../modules/nix-serve.nix
+    ../../modules/github-actions.nix  # Clés SSH pour GitHub Actions
   ];
 
   system.stateVersion = "25.05";

--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -4,8 +4,8 @@
   imports = [
     ./hardware-configuration.nix
     (import ../../modules/sops.nix { defaultSopsFile = ../../secrets/mimosa.yaml; })
-    ../../modules/tailscale.nix  # <--- AJOUTE ÇA
-    # ... tes autres imports
+    ../../modules/tailscale.nix
+    ../../modules/github-actions.nix  # Clés SSH pour GitHub Actions
   ];
 
   # Système

--- a/modules/github-actions.nix
+++ b/modules/github-actions.nix
@@ -1,0 +1,38 @@
+# ============================================================================
+# Module "github-actions.nix"
+# ---------------------------------------------------------------------------
+# Configure les clés SSH publiques pour permettre à GitHub Actions de se
+# connecter aux serveurs via Tailscale pour les déploiements automatisés.
+#
+# Usage:
+#   - Magnolia : Permet à GitHub Actions de builder et pousser au cache
+#   - Mimosa : Permet à GitHub Actions de déployer les nouvelles configs
+#
+# Sécurité:
+#   - Les clés privées sont stockées dans GitHub Secrets (chiffrées)
+#   - Les clés publiques sont ici (pas sensibles, peuvent être versionnées)
+#   - Connexion uniquement via Tailscale (réseau privé chiffré)
+# ============================================================================
+
+{ config, lib, ... }:
+
+{
+  # Clés SSH publiques pour GitHub Actions
+  # Générées dans 1Password et utilisées par le workflow de déploiement
+  environment.etc."ssh/authorized_keys.d/jeremie-github-actions" = {
+    text = ''
+      # GitHub Actions - Magnolia Deploy Key
+      # Utilisée pour builder les configurations sur Magnolia
+      # Générée le: 2025-11-25
+      # Workflow: .github/workflows/deploy.yml (j12zdotcom)
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ5gpDmTT2rn0YEzfNc5/Em5ptIeQ6DktjfAVQvboX6F github-actions@magnolia
+
+      # GitHub Actions - Mimosa Deploy Key
+      # Utilisée pour déployer sur Mimosa
+      # Générée le: 2025-11-25
+      # Workflow: .github/workflows/deploy.yml (j12zdotcom)
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFtEzoTJZxux04Ex1em5erjDq1WPp9YtF7uoP9Sz+no/ github-actions@mimosa
+    '';
+    mode = "0644";
+  };
+}


### PR DESCRIPTION
- Create modules/github-actions.nix for CI/CD SSH access
- Import module on Magnolia and Mimosa
- Keys managed declaratively (versionned, reproducible)
- Magnolia key: ...boX6F
- Mimosa key: ...z+no/

This enables GitHub Actions workflows to SSH into both servers via Tailscale for automated deployments.