### PR TITLE
feat: add GitHub Deploy Key support for Magnolia

### DIFF
--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -7,6 +7,7 @@
     ../../modules/tailscale.nix
     ../../modules/nix-serve.nix
     ../../modules/github-actions.nix  # Clés SSH pour GitHub Actions
+    ../../modules/github-deploy.nix   # Deploy Key pour pusher vers GitHub
   ];
 
   system.stateVersion = "25.05";

--- a/modules/github-deploy.nix
+++ b/modules/github-deploy.nix
@@ -1,0 +1,60 @@
+# ============================================================================
+# Module "github-deploy.nix"
+# ---------------------------------------------------------------------------
+# Configure une Deploy Key pour permettre à un serveur de pusher vers GitHub.
+# Utilisé principalement pour que Magnolia puisse commit/push le flake.lock
+# après avoir buildé.
+#
+# Usage:
+#   - La clé privée est stockée dans sops-nix (chiffrée)
+#   - La clé publique doit être ajoutée comme Deploy Key sur GitHub
+#   - Git est configuré pour utiliser cette clé automatiquement
+# ============================================================================
+
+{ config, lib, pkgs, ... }:
+
+{
+  # Installer Git si ce n'est pas déjà fait
+  environment.systemPackages = with pkgs; [
+    git
+  ];
+
+  # Configuration de la Deploy Key SSH
+  sops.secrets."github-deploy-key" = {
+    sopsFile = ../../secrets/magnolia.yaml;
+    mode = "0600";
+    owner = "jeremie";
+    group = "users";
+    path = "/home/jeremie/.ssh/github-deploy";
+  };
+
+  # Configuration SSH pour utiliser la Deploy Key avec GitHub
+  programs.ssh.extraConfig = ''
+    Host github.com
+      HostName github.com
+      User git
+      IdentityFile /home/jeremie/.ssh/github-deploy
+      IdentitiesOnly yes
+  '';
+
+  # Configuration Git globale pour jeremie
+  environment.etc."gitconfig".text = ''
+    [user]
+      name = Jeremie Alcaraz
+      email = jeremie@alcaraz.dev
+
+    [init]
+      defaultBranch = main
+
+    [core]
+      editor = vim
+
+    [safe]
+      directory = /home/jeremie/nixos
+  '';
+
+  # Assure que le répertoire .ssh existe avec les bonnes permissions
+  systemd.tmpfiles.rules = [
+    "d /home/jeremie/.ssh 0700 jeremie users - -"
+  ];
+}

--- a/secrets/magnolia.yaml.example
+++ b/secrets/magnolia.yaml.example
@@ -17,6 +17,15 @@
 # Mais avec sops, on chiffre quand même pour une sécurité maximale
 jeremie-password-hash: $6$g/9Fke6IjYVALC5S$.uMMuJpIgro1MxwzBtvBMG7G2pP88ulMtl91kPWdg3nEuE3uigDQ164yqvtEEGKiFtuN8RaFok66AiIIwErvq1
 
+# Deploy Key pour pusher vers GitHub (nix-config)
+# Générer avec: ssh-keygen -t ed25519 -C "magnolia-deploy@github"
+# La clé publique doit être ajoutée comme Deploy Key sur GitHub
+# (Settings → Deploy keys → Add deploy key → Allow write access)
+github-deploy-key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  [Votre clé privée SSH ici - format multi-lignes]
+  -----END OPENSSH PRIVATE KEY-----
+
 # Autres secrets peuvent être ajoutés ici
 # exemple:
 # vpn-key: ma-clé-vpn-secrète


### PR DESCRIPTION
Permet à Magnolia de pusher vers GitHub pour automatiser le commit du flake.lock après les builds. La clé privée est stockée de manière sécurisée via sops-nix.

- Nouveau module: modules/github-deploy.nix
- Configuration SSH pour github.com
- Configuration Git globale
- Documentation dans magnolia.yaml.example