### PR TITLE
feat: add interactive gu function with auto-rebuild prompt

### DIFF
--- a/home/jeremie.nix
+++ b/home/jeremie.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ../modules/aliases.nix
+    ../modules/fish-functions.nix
   ];
 
   # Version de Home Manager (doit correspondre à la version NixOS)

--- a/modules/aliases.nix
+++ b/modules/aliases.nix
@@ -77,8 +77,8 @@
       gl = "git log --oneline --graph --decorate -10";
       gla = "git log --oneline --graph --decorate --all -20";
 
-      # Mise à jour forcée pour nœuds follower (écrase les modifications locales)
-      gu = "git fetch --all; and git reset --hard origin/main";
+      # Note: 'gu' est maintenant une fonction (voir fish-functions.nix)
+      # Elle propose interactivement de rebuild magnolia après un git pull réussi
 
       # ═══════════════════════════════════════════════════
       # 🛠️ SYSTEMD - Gestion des services

--- a/modules/fish-functions.nix
+++ b/modules/fish-functions.nix
@@ -1,0 +1,64 @@
+{ config, pkgs, osConfig, ... }:
+
+{
+  # Fish shell functions - Fonctions interactives avancées
+  programs.fish = {
+    functions = {
+      # ═══════════════════════════════════════════════════
+      # 🔄 Git Update with Auto-Rebuild Prompt (Magnolia)
+      # ═══════════════════════════════════════════════════
+
+      # Remplace l'alias 'gu' par une fonction interactive
+      # Sur magnolia, propose automatiquement de rebuild après un pull réussi
+      gu = {
+        description = "Git fetch + hard reset, puis propose rebuild sur magnolia";
+        body = ''
+          # Couleurs
+          set -l GREEN '\033[0;32m'
+          set -l BLUE '\033[0;34m'
+          set -l YELLOW '\033[1;33m'
+          set -l NC '\033[0m' # No Color
+
+          echo -e "$BLUE🔄 Syncing from GitHub...$NC"
+
+          # Git fetch et reset
+          if git fetch --all; and git reset --hard origin/main
+            echo -e "$GREEN✓ Repository updated successfully!$NC"
+            echo ""
+
+            # Si on est sur magnolia, proposer de rebuild
+            if test (hostname) = "magnolia"
+              echo -e "$YELLOW🌸 You're on Magnolia - Do you want to rebuild the configuration?$NC"
+              echo -e "$BLUE   This will apply the latest changes to the system.$NC"
+              echo ""
+
+              # Lire la réponse de l'utilisateur (y/N)
+              read -l -P "Rebuild magnolia? [y/N] " confirm
+
+              switch $confirm
+                case Y y
+                  echo ""
+                  echo -e "$BLUE🔨 Rebuilding magnolia...$NC"
+                  sudo nixos-rebuild switch --flake .#magnolia
+
+                  if test $status -eq 0
+                    echo ""
+                    echo -e "$GREEN✓ Magnolia successfully rebuilt!$NC"
+                  else
+                    echo ""
+                    echo -e "$YELLOW⚠ Rebuild failed. Check the errors above.$NC"
+                  end
+                case '*'
+                  echo ""
+                  echo -e "$BLUE ℹ Skipped rebuild. Run 'r' when you're ready.$NC"
+              end
+            end
+          else
+            echo -e "$YELLOW⚠ Git update failed!$NC"
+            return 1
+          end
+        '';
+      };
+    };
+  };
+}


### PR DESCRIPTION
Replaces the 'gu' alias with an interactive fish function that:
- Performs git fetch + hard reset as before
- On magnolia, automatically prompts to rebuild after successful pull
- Provides colored output for better UX
- Allows user to skip rebuild if needed

This makes it much easier to keep magnolia up-to-date with a single command that handles both git sync and system rebuild.

Usage:
  gu              # On magnolia: pulls + prompts for rebuild
  gu              # On other hosts: just pulls (no prompt)