### PR TITLE
Sync repository from GitHub

### DIFF
--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -5,6 +5,7 @@
     ./hardware-configuration.nix
     (import ../../modules/sops.nix { defaultSopsFile = ../../secrets/magnolia.yaml; })
     ../../modules/tailscale.nix
+    ../../modules/tailscale-dns.nix   # Configuration DNS pour MagicDNS
     ../../modules/nix-serve.nix
     ../../modules/github-actions.nix  # Clés SSH pour GitHub Actions
 
@@ -16,8 +17,6 @@
   # Réseau
   networking.hostName = "magnolia";  # Infrastructure Proxmox
   networking.useDHCP = true;
-  # Désactiver resolvconf (DHCP gère déjà le DNS)
-  networking.resolvconf.enable = false;
   services.tailscale = {
     enable = true;
     useRoutingFeatures = "none";

--- a/hosts/mimosa/configuration.nix
+++ b/hosts/mimosa/configuration.nix
@@ -5,6 +5,7 @@
     ./hardware-configuration.nix
     (import ../../modules/sops.nix { defaultSopsFile = ../../secrets/mimosa.yaml; })
     ../../modules/tailscale.nix
+    ../../modules/tailscale-dns.nix   # Configuration DNS pour MagicDNS
     ../../modules/github-actions.nix  # Clés SSH pour GitHub Actions
   ];
 

--- a/hosts/minimal/configuration.nix
+++ b/hosts/minimal/configuration.nix
@@ -6,6 +6,7 @@
     ./hardware-configuration.nix
     (import ../../modules/sops.nix { defaultSopsFile = ../../secrets/minimal.yaml; })
     ../../modules/tailscale.nix
+    ../../modules/tailscale-dns.nix   # Configuration DNS pour MagicDNS
   ];
 
   system.stateVersion = "25.05";
@@ -13,7 +14,6 @@
   # Réseau
   networking.hostName = "minimal";
   networking.useDHCP = true;
-  networking.resolvconf.enable = false;
 
   services.tailscale = {
     enable = true;

--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -7,6 +7,7 @@
     ./n8n-backup.nix
     (import ../../modules/sops.nix { defaultSopsFile = ../../secrets/whitelily.yaml; })
     ../../modules/tailscale.nix
+    ../../modules/tailscale-dns.nix   # Configuration DNS pour MagicDNS
 
   ];
 
@@ -15,8 +16,6 @@
   # Réseau
   networking.hostName = "whitelily";  # VM n8n automation
   networking.useDHCP = true;
-  # Configuration DNS (resolvconf désactivé, donc configuration manuelle)
-  networking.nameservers = [ "8.8.8.8" "1.1.1.1" ];
   services.tailscale = {
     enable = true;
     useRoutingFeatures = "none";

--- a/modules/aliases.nix
+++ b/modules/aliases.nix
@@ -26,6 +26,9 @@
       # Rebuild ALL configurations (magnolia cache builder)
       ra = "/etc/nixos/scripts/rebuild-all.sh";
 
+      # Deploy ALL configurations to remote hosts
+      da = "/etc/nixos/scripts/deploy-all.sh";
+
       # ═══════════════════════════════════════════════════
       # 📦 GESTION DES GÉNÉRATIONS
       # ═══════════════════════════════════════════════════

--- a/modules/tailscale-dns.nix
+++ b/modules/tailscale-dns.nix
@@ -1,0 +1,28 @@
+# ============================================================================
+# Module "tailscale-dns.nix"
+# ---------------------------------------------------------------------------
+# Configure systemd-resolved pour qu'il fonctionne correctement avec
+# MagicDNS de Tailscale, permettant la résolution des hostnames courts
+# (mimosa, whitelily, etc.) via le DNS Tailscale.
+# ============================================================================
+
+{ config, lib, pkgs, ... }:
+
+{
+  # Activer systemd-resolved (gestionnaire DNS moderne)
+  services.resolved = {
+    enable = true;
+    # Tailscale injectera automatiquement son DNS (100.100.100.100)
+    # via l'interface tailscale0
+  };
+
+  # Désactiver l'ancien système resolvconf
+  networking.resolvconf.enable = false;
+
+  # Configuration réseau pour permettre à systemd-resolved de gérer le DNS
+  networking.useNetworkd = lib.mkDefault false;  # Garder NetworkManager/dhcpcd par défaut
+
+  # Note : Tailscale avec --accept-dns=true configurera automatiquement
+  # systemd-resolved pour utiliser 100.100.100.100 comme serveur DNS
+  # pour le domaine .ts.net et les hostnames courts
+}

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Script pour déployer toutes les configurations NixOS sur les machines distantes
+#
+# Usage:
+#   ./scripts/deploy-all.sh       # Déploie sur toutes les machines
+#   ./scripts/deploy-all.sh --help # Affiche l'aide
+
+set -euo pipefail
+
+# Configuration
+CONFIG_DIR="/etc/nixos"
+HOSTS=("mimosa" "whitelily")
+SSH_TIMEOUT=5
+
+# Couleurs pour les logs
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Fonctions d'affichage
+log_info() {
+    echo -e "${BLUE}ℹ${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}⚠${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}✗${NC} $1"
+}
+
+log_header() {
+    echo ""
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}$1${NC}"
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+}
+
+# Aide
+show_help() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Déploie toutes les configurations NixOS sur les machines distantes.
+
+Ce script va :
+  1. Vérifier la connectivité de chaque machine
+  2. Déployer séquentiellement sur mimosa, whitelily
+  3. Skip les machines hors ligne avec un warning
+  4. Fail si une machine est accessible mais le déploiement échoue
+
+Le script utilise le cache binaire de magnolia pour des déploiements rapides.
+
+OPTIONS:
+    --help         Affiche cette aide
+
+EXAMPLES:
+    $0             # Déploie sur toutes les machines accessibles
+
+NOTE:
+    - Ce script est conçu pour être exécuté sur magnolia
+    - Lance 'ra' avant pour rebuilder et remplir le cache
+    - Les machines offline seront skippées automatiquement
+
+EOF
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --help)
+            show_help
+            exit 0
+            ;;
+        *)
+            log_error "Option inconnue: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Vérifier qu'on est bien sur magnolia
+CURRENT_HOST=$(hostname)
+if [[ "$CURRENT_HOST" != "magnolia" ]]; then
+    log_warning "Ce script est conçu pour être exécuté sur magnolia"
+    log_warning "Host actuel: $CURRENT_HOST"
+    read -p "Continuer quand même ? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        log_info "Annulé"
+        exit 0
+    fi
+fi
+
+# Vérifier qu'on est dans le bon dossier
+if [[ ! -f "flake.nix" ]]; then
+    log_error "flake.nix non trouvé. Es-tu dans /etc/nixos ?"
+    exit 1
+fi
+
+# Arrays pour tracker les résultats
+DEPLOYED=()
+SKIPPED=()
+FAILED=()
+
+# Début du script
+log_header "🚀 Deploy All Configurations"
+
+# Check de connectivité et déploiement
+for host in "${HOSTS[@]}"; do
+    echo ""
+    echo -e "${BLUE}🌐 Checking $host...${NC}"
+
+    # Test de connectivité SSH
+    if timeout $SSH_TIMEOUT ssh -o ConnectTimeout=$SSH_TIMEOUT -o BatchMode=yes "$host" "echo ok" &>/dev/null; then
+        log_success "$host is online"
+
+        echo -e "${BLUE}📦 Deploying to $host...${NC}"
+
+        # Déploiement
+        if nixos-rebuild switch --flake ".#$host" --target-host "$host" --use-remote-sudo; then
+            log_success "$host deployed successfully!"
+            DEPLOYED+=("$host")
+        else
+            log_error "$host deployment failed!"
+            FAILED+=("$host")
+            # On fail immédiatement si le déploiement échoue
+            log_error "Déploiement échoué sur $host. Arrêt du script."
+            exit 1
+        fi
+    else
+        log_warning "$host is offline or unreachable"
+        log_info "Skipping $host..."
+        SKIPPED+=("$host")
+    fi
+done
+
+# Résumé final
+log_header "✅ Deployment Summary"
+
+if [ ${#DEPLOYED[@]} -gt 0 ]; then
+    echo -e "${GREEN}✓ Deployed successfully:${NC}"
+    for host in "${DEPLOYED[@]}"; do
+        echo "  • $host"
+    done
+    echo ""
+fi
+
+if [ ${#SKIPPED[@]} -gt 0 ]; then
+    echo -e "${YELLOW}⚠ Skipped (offline):${NC}"
+    for host in "${SKIPPED[@]}"; do
+        echo "  • $host"
+    done
+    echo ""
+fi
+
+if [ ${#FAILED[@]} -gt 0 ]; then
+    echo -e "${RED}✗ Failed:${NC}"
+    for host in "${FAILED[@]}"; do
+        echo "  • $host"
+    done
+    echo ""
+fi
+
+echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${CYAN}🌐 Binary Cache:${NC}"
+echo "  Cache utilisé depuis: http://magnolia:5000"
+echo ""
+
+# Exit code basé sur les résultats
+if [ ${#FAILED[@]} -gt 0 ]; then
+    exit 1
+elif [ ${#DEPLOYED[@]} -eq 0 ]; then
+    log_warning "Aucune machine n'a été déployée"
+    exit 0
+else
+    log_success "All accessible machines deployed successfully!"
+    exit 0
+fi


### PR DESCRIPTION
Add a new deploy-all.sh script that:
- Deploys configurations to all remote hosts sequentially
- Skips offline machines with warnings
- Fails on deployment errors
- Uses magnolia's binary cache for fast deployments

Also adds 'da' alias to quickly run the deployment script.