### PR TITLE
fix: configure systemd-resolved to manage /etc/resolv.conf

### DIFF
--- a/modules/tailscale-dns.nix
+++ b/modules/tailscale-dns.nix
@@ -12,15 +12,27 @@
   # Activer systemd-resolved (gestionnaire DNS moderne)
   services.resolved = {
     enable = true;
+    dnssec = "false";  # Désactiver DNSSEC pour éviter les conflits
     # Tailscale injectera automatiquement son DNS (100.100.100.100)
-    # via l'interface tailscale0
+    # via l'interface tailscale0 avec --accept-dns=true
   };
 
   # Désactiver l'ancien système resolvconf
   networking.resolvconf.enable = false;
 
-  # Configuration réseau pour permettre à systemd-resolved de gérer le DNS
-  networking.useNetworkd = lib.mkDefault false;  # Garder NetworkManager/dhcpcd par défaut
+  # IMPORTANT: Faire en sorte que /etc/resolv.conf soit un symlink
+  # vers le stub resolver de systemd-resolved (127.0.0.53)
+  # Cela permet à systemd-resolved de gérer correctement le DNS
+  system.activationScripts.fixResolvConf = lib.stringAfter [ "etc" ] ''
+    # Supprimer l'ancien resolv.conf s'il existe et n'est pas un symlink
+    if [ -e /etc/resolv.conf ] && [ ! -L /etc/resolv.conf ]; then
+      rm -f /etc/resolv.conf
+    fi
+    # Créer le symlink vers systemd-resolved stub resolver
+    if [ ! -e /etc/resolv.conf ]; then
+      ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+    fi
+  '';
 
   # Note : Tailscale avec --accept-dns=true configurera automatiquement
   # systemd-resolved pour utiliser 100.100.100.100 comme serveur DNS


### PR DESCRIPTION
Add activation script to create symlink from /etc/resolv.conf to systemd-resolved stub resolver. This allows systemd-resolved to properly manage DNS and lets Tailscale inject its MagicDNS settings.