### PR TITLE
feat: use binary cache for deployments instead of SSH copy

### DIFF
--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -128,7 +128,8 @@ for host in "${HOSTS[@]}"; do
         echo -e "${BLUE}📦 Deploying to $host...${NC}"
 
         # Déploiement
-        if nixos-rebuild switch --flake ".#$host" --target-host "$host" --use-remote-sudo; then
+        # --use-substitutes : utilise le cache HTTP de magnolia au lieu de copier via SSH
+        if nixos-rebuild switch --flake ".#$host" --target-host "$host" --use-remote-sudo --use-substitutes; then
             log_success "$host deployed successfully!"
             DEPLOYED+=("$host")
         else


### PR DESCRIPTION
Add --use-substitutes flag to nixos-rebuild in deploy script. This makes remote hosts download from magnolia's HTTP cache instead of copying store paths directly via SSH, which fixes signature verification issues.