### PR TITLE
feat: manage n8n SSH key with sops for full reproducibility

### DIFF
--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -36,6 +36,8 @@
       "n8n/basic_user" = { owner = "root"; group = "root"; mode = "0400"; };
       "n8n/basic_pass" = { owner = "root"; group = "root"; mode = "0400"; };
       "n8n/db_password" = { owner = "root"; group = "root"; mode = "0400"; };
+      # Clé SSH pour le conteneur n8n (accès sans mot de passe à d'autres machines)
+      "n8n_ssh/private_key" = { owner = "root"; group = "root"; mode = "0400"; };
       # Cloudflare Tunnel token (simplifié)
       "cloudflared/token" = { owner = "cloudflared"; group = "cloudflared"; mode = "0400"; };
       # GitHub token pour auto-update workflow


### PR DESCRIPTION
Replace SSH key generation with sops-managed secret deployment. Now the SSH private key is stored encrypted in the repository and deployed on each rebuild, ensuring perfect reproducibility.

Changes:
- Add n8n_ssh/private_key secret to sops configuration
- Replace n8n-ssh-keygen service with n8n-ssh-setup service
- Deploy SSH key from sops instead of generating new one
- Generate public key from private key at deployment time
- Maintain proper permissions (1000:1000) for container access

Benefits:
- Fully reproducible: rebuilding VM from scratch uses same SSH key
- Secure: private key stored encrypted in repo via sops
- No manual backup needed: key is part of declarative config