### PR TITLE
fix: remove non-existent sops-nix.service dependency

### DIFF
--- a/hosts/whitelily/n8n.nix
+++ b/hosts/whitelily/n8n.nix
@@ -176,8 +176,6 @@ EOF
     description = "Setup SSH key for n8n container from sops secrets";
     wantedBy = [ "multi-user.target" ];
     before = [ "podman-n8n.service" ];
-    after = [ "sops-nix.service" ];
-    requires = [ "sops-nix.service" ];
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;


### PR DESCRIPTION
The sops-nix.service unit doesn't exist. Sops secrets are available early in the boot process without a dedicated systemd service.

Removed the after/requires dependency on sops-nix.service which was causing the service to fail to start.