### PR TITLE
Simplify n8n backup folder structure on Google Drive

### DIFF
--- a/hosts/whitelily/configuration.nix
+++ b/hosts/whitelily/configuration.nix
@@ -60,8 +60,8 @@
     logFile = "/var/log/n8n-backup.log";
     
     # Chemin dans Google Drive où stocker les backups
-    # Tu dois avoir créé ce dossier dans GDrive : backups/n8n
-    gdrivePath = "backups/n8n";
+    # Le folder_id pointe vers le dossier "backups", donc on spécifie juste "n8n"
+    gdrivePath = "n8n";
 
     # Note: L'ID du dossier Google Drive est lu depuis les secrets sops
     # (google_drive/folder_id) et n'a plus besoin d'être configuré ici

--- a/scripts/restore-n8n.sh
+++ b/scripts/restore-n8n.sh
@@ -84,7 +84,7 @@ log "☁️  Récupération de la liste des backups..."
 
 # On récupère "Temps;Nom" (--format "tp"), on trie du plus récent au plus vieux, et on garde le nom
 # Utilisation de 'sort' car 'rclone lsf' ne supporte pas le tri natif
-SELECTED_FILE=$(rclone --config "$TEMP_DIR/rclone.conf" lsf gdrive:backups/n8n \
+SELECTED_FILE=$(rclone --config "$TEMP_DIR/rclone.conf" lsf gdrive:n8n \
     --files-only \
     --include "*.tar.gz" \
     --format "tp" \
@@ -105,7 +105,7 @@ success "Backup sélectionné : $SELECTED_FILE"
 
 # 4. Téléchargement
 log "⬇️  Téléchargement de l'archive..."
-rclone --config "$TEMP_DIR/rclone.conf" copy "gdrive:backups/n8n/$SELECTED_FILE" "$TEMP_DIR/" --progress
+rclone --config "$TEMP_DIR/rclone.conf" copy "gdrive:n8n/$SELECTED_FILE" "$TEMP_DIR/" --progress
 
 ARCHIVE_PATH="$TEMP_DIR/$SELECTED_FILE"
 


### PR DESCRIPTION
Update backup path from "backups/n8n/backups/n8n" to "backups/n8n" by:
- Changing gdrivePath from "backups/n8n" to "n8n" in configuration.nix
- Updating restore-n8n.sh to use new path "gdrive:n8n"
- folder_id now points to "backups" folder instead of nested structure

This eliminates redundant folder nesting and simplifies navigation.