### PR TITLE
fix(dandelion): correct permissions for gitea admin password secret

### DIFF
--- a/hosts/dandelion/configuration.nix
+++ b/hosts/dandelion/configuration.nix
@@ -28,8 +28,8 @@
       sshKeyPaths = [];
     };
     secrets = {
-      # Secrets Gitea
-      "gitea/admin_password" = { owner = "root"; group = "root"; mode = "0400"; };
+      # Secrets Gitea - accessible par l'utilisateur gitea
+      "gitea/admin_password" = { owner = "gitea"; group = "gitea"; mode = "0400"; };
     };
   };
 


### PR DESCRIPTION
The gitea-admin-setup service runs as user 'gitea' but the secret was owned by root. Change secret owner to gitea:gitea so the service can read it.

Fixes: Permission denied when reading /run/secrets/gitea/admin_password